### PR TITLE
guardrails-clarification

### DIFF
--- a/modules/operations/pages/astream-limits.adoc
+++ b/modules/operations/pages/astream-limits.adoc
@@ -65,7 +65,7 @@ Max throughput for a *non-partitioned topic* or a *single partition of a partiti
 |Not set
 |===
 
-_*These guardrails cannot be changed._
+_*These guardrails cannot be changed._ +
 _**Max message size can be changed on dedicated clusters, but not serverless clusters. If you need assistance, open https://support.datastax.com[a support ticket]._
 
 == Function and connector resource limits

--- a/modules/operations/pages/astream-limits.adoc
+++ b/modules/operations/pages/astream-limits.adoc
@@ -65,7 +65,7 @@ Max throughput for a *non-partitioned topic* or a *single partition of a partiti
 |Not set
 |===
 
-* These guardrails cannot be changed.
+*These guardrails cannot be changed.
 
 == Function and connector resource limits
 

--- a/modules/operations/pages/astream-limits.adoc
+++ b/modules/operations/pages/astream-limits.adoc
@@ -65,7 +65,8 @@ Max throughput for a *non-partitioned topic* or a *single partition of a partiti
 |Not set
 |===
 
-_*These guardrails cannot be changed._ +
+_*These guardrails cannot be changed._
+
 _**Max message size can be changed on dedicated clusters, but not serverless clusters. If you need assistance, open https://support.datastax.com[a support ticket]._
 
 == Function and connector resource limits

--- a/modules/operations/pages/astream-limits.adoc
+++ b/modules/operations/pages/astream-limits.adoc
@@ -28,7 +28,7 @@ Guardrails are initially provisioned in the default settings by {product_name} a
 |Number of topics per namespace
 |100
 
-|Max message size*
+|Max message size**
 |5MB (default)
 
 |Max throughput per topic for consumer
@@ -65,7 +65,8 @@ Max throughput for a *non-partitioned topic* or a *single partition of a partiti
 |Not set
 |===
 
-*These guardrails cannot be changed.
+_*These guardrails cannot be changed._
+_**Max message size can be changed on dedicated clusters, but not serverless clusters. If you need assistance, open https://support.datastax.com[a support ticket]._
 
 == Function and connector resource limits
 

--- a/modules/operations/pages/astream-limits.adoc
+++ b/modules/operations/pages/astream-limits.adoc
@@ -19,7 +19,7 @@ Guardrails are initially provisioned in the default settings by {product_name} a
 |*Guardrail*
 |*Limit*
 
-|Number of tenants per organization
+|Number of tenants per organization*
 |10
 
 |Number of namespaces per tenant
@@ -28,7 +28,7 @@ Guardrails are initially provisioned in the default settings by {product_name} a
 |Number of topics per namespace
 |100
 
-|Max message size
+|Max message size*
 |5MB (default)
 
 |Max throughput per topic for consumer
@@ -64,6 +64,8 @@ Max throughput for a *non-partitioned topic* or a *single partition of a partiti
 |Subscription Expiry
 |Not set
 |===
+
+* These guardrails cannot be changed.
 
 == Function and connector resource limits
 


### PR DESCRIPTION
Clarify that these guardrails cannot be changed: 

Number of tenants per organization*
Max message size*

Coppi build: https://coppi.aws.dsinternal.org/streaming-docs/clarify-guardrails/astra-streaming/operations/astream-limits.html