### PR TITLE
add-release-note

### DIFF
--- a/modules/operations/pages/astream-release-notes.adoc
+++ b/modules/operations/pages/astream-release-notes.adoc
@@ -5,6 +5,18 @@
 
 {product_name} release notes provide information about new and improved features, known and resolved issues, and bug fixes.
 
+== 17 April 2023
+
+Custom functions can now only be created by *qualified organizations*.
+A *qualified organization* is an organization on the https://docs.datastax.com/en/astra-serverless/docs/manage/org/manage-billing.html#_pay_as_you_go_plans[Pay As You Go] plan with a payment method on file.
+Upgrade your organization to a qualified organization by:
+
+* Enrolling in the https://docs.datastax.com/en/astra-serverless/docs/manage/org/manage-billing.html#_pay_as_you_go_plans[Pay As You Go] plan in the {astra_ui} with a payment method. For more, see https://docs.datastax.com/en/astra-serverless/docs/plan/plan-options.html[Plan Options].
+* Contacting our sales team to see how we can help.
+* Opening https://support.datastax.com[a support ticket].
+
+Unqualified orgs can still use xref:streaming-learning:functions:index.adoc[transform functions].
+
 // == 2 December 2022
 
 // {product_name} now supports https://pulsar.apache.org/docs/next/txn-how[Pulsar transactions].


### PR DESCRIPTION
Custom functions can only be created by *qualified organizations*.
A *qualified organization* is an organization on the https://docs.datastax.com/en/astra-serverless/docs/manage/org/manage-billing.html#_pay_as_you_go_plans[Pay As You Go] plan with a payment method on file.
Upgrade your organization to a qualified organization by:

* Enrolling in the https://docs.datastax.com/en/astra-serverless/docs/manage/org/manage-billing.html#_pay_as_you_go_plans[Pay As You Go] plan in the {astra_ui} with a payment method. For more, see https://docs.datastax.com/en/astra-serverless/docs/plan/plan-options.html[Plan Options].
* Contacting our sales team to see how we can help.
* Opening https://support.datastax.com[a support ticket].

Unqualified orgs can still use xref:streaming-learning:functions:index.adoc[transform functions].