### PR TITLE
Private link clarification

### DIFF
--- a/modules/operations/pages/private-connectivity.adoc
+++ b/modules/operations/pages/private-connectivity.adoc
@@ -1,6 +1,6 @@
 = Private connectivity
 
-To better protect your streaming connections, connect {product_name} to a private link service for <<inbound>> connectivity, or to a private endpoint for <<outbound>> connectivity.
+To better protect your streaming connections, connect {product_name} to a private link service for <<inbound,inbound>> connectivity, or to a private endpoint for <<outbound,outbound>> connectivity.
 
 Private connections are only available within the same cloud provider and region as your {product_name} cluster.
 

--- a/modules/operations/pages/private-connectivity.adoc
+++ b/modules/operations/pages/private-connectivity.adoc
@@ -4,12 +4,15 @@ To better protect your streaming connections, connect {product_name} to a privat
 
 Private connections are only available within the same cloud provider and region as your {product_name} cluster.
 
-To open a private link service or private endpoint, open https://support.datastax.com[a support ticket].
+To open a private link service or private endpoint, open https://support.datastax.com[a support ticket] and include the <<credentials,credentials>> required for your cloud provider.
 
-== Supported traffic
+== Inbound traffic
 
-{product_name} supports the following inbound traffic (i.e. User → {product_name}).
+{product_name} supports the following inbound traffic (i.e. User's private endpoint → {product_name}).
 
+Inbound traffic describes Pulsar, Kafka, and RabbitMQ messaging traffic, as well as Prometheus metrics traffic flowing from a user's private endpoint to {product_name}.
+You create a connection to our private link service, and we route traffic to your {product_name} cluster.
+If you have multiple tenants, namespaces, 
 The private link service pattern is the same across cloud providers, but the hostname will vary depending on your cloud provider and region.
 
 .Inbound private link service endpoints
@@ -31,12 +34,16 @@ The private link service pattern is the same across cloud providers, but the hos
 |prometheus-azure-eastus.private.streaming.datastax.com
 |===
 
-{product_name} also supports private outbound traffic on a case-by-case basis.
-To open an outbound private endpoint, open https://support.datastax.com[a support ticket].
+== Outbound traffic
+{product_name} also supports private outbound traffic (i.e. {product_name} → User's private endpoint) on a case-by-case basis.
+To open an outbound private endpoint, open https://support.datastax.com[a support ticket] and include the <<credentials,credentials>> required for your cloud provider.
 
+
+
+== Cloud provider credentials
 For more on connecting to your cloud provider, see your cloud provider's documentation.
 Each cloud provider will require different credentials to connect to the private endpoint.
-
+[#credentials]
 .Cloud providers
 [cols=3*,options=header]
 |===

--- a/modules/operations/pages/private-connectivity.adoc
+++ b/modules/operations/pages/private-connectivity.adoc
@@ -10,9 +10,11 @@ To open a private link service or private endpoint, open https://support.datasta
 
 {product_name} supports inbound traffic (i.e. Your private endpoint → {product_name}).
 The first inbound traffic pattern describes Pulsar, Kafka, and RabbitMQ messaging traffic, as well as Prometheus metrics traffic, flowing from a user's private endpoint to {product_name}.
+
 You create a connection to our private link service, and we route traffic to your {product_name} cluster.
 If you have multiple tenants, they can have different VPCs. The different VPCs will have the same private FQDN with differing VNETs.
 The traffic on different private end point connections is isolated until it reaches our load balancer.
+
 The private link service pattern is the same across cloud providers, but the hostname will vary depending on your cloud provider and region.
 [#inbound]
 .Inbound private link service endpoints

--- a/modules/operations/pages/private-connectivity.adoc
+++ b/modules/operations/pages/private-connectivity.adoc
@@ -8,11 +8,11 @@ To open a private link service or private endpoint, open https://support.datasta
 
 == Inbound traffic
 
-{product_name} supports the following inbound traffic (i.e. User's private endpoint → {product_name}).
-
-Inbound traffic describes Pulsar, Kafka, and RabbitMQ messaging traffic, as well as Prometheus metrics traffic flowing from a user's private endpoint to {product_name}.
+{product_name} supports inbound traffic (i.e. Your private endpoint → {product_name}).
+The first inbound traffic pattern describes Pulsar, Kafka, and RabbitMQ messaging traffic, as well as Prometheus metrics traffic, flowing from a user's private endpoint to {product_name}.
 You create a connection to our private link service, and we route traffic to your {product_name} cluster.
-If you have multiple tenants, namespaces, 
+If you have multiple tenants, they can have different VPCs. The different VPCs will have the same private FQDN with differing VNETs.
+The traffic on different private end point connections is isolated until it reaches our load balancer.
 The private link service pattern is the same across cloud providers, but the hostname will vary depending on your cloud provider and region.
 
 .Inbound private link service endpoints
@@ -35,10 +35,11 @@ The private link service pattern is the same across cloud providers, but the hos
 |===
 
 == Outbound traffic
-{product_name} also supports private outbound traffic (i.e. {product_name} → User's private endpoint) on a case-by-case basis.
+{product_name} also supports private outbound traffic (i.e. {product_name} → Your private endpoint) on a case-by-case basis.
+
+The outbound traffic pattern creates a private endpoint in {product_name} that connects to your private link service. We open a port on the tenant's firewall (firewalls are per tenant) so connectors and functions (running in a dedicated namespace on our cluster) can connect to your private network.
+
 To open an outbound private endpoint, open https://support.datastax.com[a support ticket] and include the <<credentials,credentials>> required for your cloud provider.
-
-
 
 == Cloud provider credentials
 For more on connecting to your cloud provider, see your cloud provider's documentation.

--- a/modules/operations/pages/private-connectivity.adoc
+++ b/modules/operations/pages/private-connectivity.adoc
@@ -1,6 +1,6 @@
 = Private connectivity
 
-To better protect your streaming connections, connect {product_name} to a private link service for inbound connectivity, or to a private endpoint for outbound connectivity.
+To better protect your streaming connections, connect {product_name} to a private link service for <<inbound>> connectivity, or to a private endpoint for <<outbound>> connectivity.
 
 Private connections are only available within the same cloud provider and region as your {product_name} cluster.
 
@@ -14,7 +14,7 @@ You create a connection to our private link service, and we route traffic to you
 If you have multiple tenants, they can have different VPCs. The different VPCs will have the same private FQDN with differing VNETs.
 The traffic on different private end point connections is isolated until it reaches our load balancer.
 The private link service pattern is the same across cloud providers, but the hostname will vary depending on your cloud provider and region.
-
+[#inbound]
 .Inbound private link service endpoints
 [cols=2*,options=header]
 |===
@@ -33,7 +33,7 @@ The private link service pattern is the same across cloud providers, but the hos
 |Prometheus Metrics
 |prometheus-azure-eastus.private.streaming.datastax.com
 |===
-
+[#outbound]
 == Outbound traffic
 {product_name} also supports private outbound traffic (i.e. {product_name} → Your private endpoint) on a case-by-case basis.
 


### PR DESCRIPTION
Clarity about including credentials in private connectivity support ticket
This page: https://docs.datastax.com/en/streaming/astra-streaming/operations/private-connectivity.html
The table lists the credential, but is not clear that customers must include this credential with their support ticket.