### PR TITLE
DOC-3853: Update/add support_url attribute

### DIFF
--- a/modules/developing/pages/astream-functions.adoc
+++ b/modules/developing/pages/astream-functions.adoc
@@ -17,7 +17,7 @@ Upgrade your organization to a qualified organization by:
 
 * Enrolling in the https://docs.datastax.com/en/astra-serverless/docs/manage/org/manage-billing.html#_pay_as_you_go_plans[Pay As You Go] plan in the {astra_ui} with a payment method. For more, see https://docs.datastax.com/en/astra-serverless/docs/plan/plan-options.html[Plan Options].
 * Contacting our sales team to see how we can help.
-* Opening https://support.datastax.com[a support ticket].
+* Opening {support_url}[a support ticket].
 
 Unqualified orgs can still use xref:streaming-learning:functions:index.adoc[transform functions].
 ====
@@ -113,7 +113,7 @@ Upgrade your organization to a qualified organization by:
 
 * Enrolling in the https://docs.datastax.com/en/astra-serverless/docs/manage/org/manage-billing.html#_pay_as_you_go_plans[Pay As You Go] plan in the {astra_ui} with a payment method. For more, see https://docs.datastax.com/en/astra-serverless/docs/plan/plan-options.html[Plan Options].
 * Contacting our sales team to see how we can help.
-* Opening https://support.datastax.com[a support ticket].
+* Opening {support_url}[a support ticket].
 ====
 
 . Use `./pulsar-admin functions list --tenant <tenant-name>` to list the functions in your tenant and confirm your new function was created.

--- a/modules/operations/pages/astream-limits.adoc
+++ b/modules/operations/pages/astream-limits.adoc
@@ -7,12 +7,12 @@ DataStax {product_name} includes guardrails and limits to ensure good practices,
 
 [NOTE]
 ====
-The below limits are for Pay As You Go clusters. These limits may be changed on <<Dedicated clusters,dedicated clusters>> if necessary. https://support.datastax.com[Contact Support] to change the limits on a dedicated cluster.
+The below limits are for Pay As You Go clusters. These limits may be changed on <<Dedicated clusters,dedicated clusters>> if necessary. {support_url}[Contact Support] to change the limits on a dedicated cluster.
 ====
 
 == {product_name} guardrails
 
-Guardrails are initially provisioned in the default settings by {product_name} and cannot be changed directly by users. If you need assistance, open https://support.datastax.com[a support ticket].
+Guardrails are initially provisioned in the default settings by {product_name} and cannot be changed directly by users. If you need assistance, open {support_url}[a support ticket].
 
 [cols=2*]
 |===
@@ -67,7 +67,7 @@ Max throughput for a *non-partitioned topic* or a *single partition of a partiti
 
 _*These guardrails cannot be changed._
 
-_**Max message size can be changed on dedicated clusters, but not serverless clusters. If you need assistance, open https://support.datastax.com[a support ticket]._
+_**Max message size can be changed on dedicated clusters, but not serverless clusters. If you need assistance, open {support_url}[a support ticket]._
 
 == Function and connector resource limits
 
@@ -85,7 +85,7 @@ Upgrade your organization to a qualified organization by:
 
 * Enrolling in the https://docs.datastax.com/en/astra-serverless/docs/manage/org/manage-billing.html#_pay_as_you_go_plans[Pay As You Go] plan in the {astra_ui} with a payment method. For more, see https://docs.datastax.com/en/astra-serverless/docs/plan/plan-options.html[Plan Options].
 * Contacting our sales team to see how we can help.
-* Opening https://support.datastax.com[a support ticket].
+* Opening {support_url}[a support ticket].
 
 Unqualified orgs can still use xref:streaming-learning:functions:index.adoc[transform functions].
 ====
@@ -224,7 +224,7 @@ These topic and namespace actions are initially provisioned in the default setti
 
 == Dedicated clusters
 
-Message throughput, rate, and message max size can be customized on dedicated clusters. If you need assistance, open https://support.datastax.com[a support ticket].
+Message throughput, rate, and message max size can be customized on dedicated clusters. If you need assistance, open {support_url}[a support ticket].
 
 [cols=2*]
 |===

--- a/modules/operations/pages/astream-release-notes.adoc
+++ b/modules/operations/pages/astream-release-notes.adoc
@@ -19,7 +19,7 @@ Upgrade your organization to a qualified organization by:
 
 * Enrolling in the https://docs.datastax.com/en/astra-serverless/docs/manage/org/manage-billing.html#_pay_as_you_go_plans[Pay As You Go] plan in the {astra_ui} with a payment method. For more, see https://docs.datastax.com/en/astra-serverless/docs/plan/plan-options.html[Plan Options].
 * Contacting our sales team to see how we can help.
-* Opening https://support.datastax.com[a support ticket].
+* Opening {support_url}[a support ticket].
 
 Unqualified orgs can still use xref:streaming-learning:functions:index.adoc[transform functions].
 
@@ -55,7 +55,7 @@ xref:developing:astream-rabbit.adoc[{starlight_rabbitmq}] is now available. {sta
 
 xref:developing:astream-kafka.adoc[{kafka_for_astra}] is now available. {kafka_for_astra} brings native Apache Kafka(R) protocol support to Apache Pulsar.
 
-== 24 March 2022 
+== 24 March 2022
 xref:developing:astream-cdc.adoc[CDC for Astra DB] is now available. CDC for Astra DB automatically captures changes in real time, de-duplicates the changes, and streams the clean set of changed data into {product_name} where it can be processed by client applications or sent to downstream systems.
 
 == 31 January 2022: General Availability

--- a/modules/operations/pages/private-connectivity.adoc
+++ b/modules/operations/pages/private-connectivity.adoc
@@ -4,7 +4,7 @@ To better protect your streaming connections, connect {product_name} to a privat
 
 Private connections are only available within the same cloud provider and region as your {product_name} cluster.
 
-To open a private link service or private endpoint, open https://support.datastax.com[a support ticket] and include the <<credentials,credentials>> required for your cloud provider.
+To open a private link service or private endpoint, open {support_url}[a support ticket] and include the <<credentials,credentials>> required for your cloud provider.
 
 == Inbound traffic
 
@@ -41,7 +41,7 @@ The private link service pattern is the same across cloud providers, but the hos
 
 The outbound traffic pattern creates a private endpoint in {product_name} that connects to your private link service. We open a port on the tenant's firewall (firewalls are per tenant) so connectors and functions (running in a dedicated namespace on our cluster) can connect to your private network.
 
-To open an outbound private endpoint, open https://support.datastax.com[a support ticket] and include the <<credentials,credentials>> required for your cloud provider.
+To open an outbound private endpoint, open {support_url}[a support ticket] and include the <<credentials,credentials>> required for your cloud provider.
 
 == Cloud provider credentials
 For more on connecting to your cloud provider, see your cloud provider's documentation.


### PR DESCRIPTION
**JIRA:** https://datastax.jira.com/browse/DOC-3853

This change updates/adds the `support_url` attribute with the correct link to the DataStax Support website.