### PR TITLE
Inaccessible pages in navigation

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,15 +1,13 @@
-* xref:astream-faq.adoc[Guides and Examples]
-
+* Guides and Examples
 ** xref:astream-faq.adoc[FAQs]
-
-** xref:astream-org-permissions.adoc[Manage permissions]
-*** xref:astream-custom-roles.adoc[Use custom roles]
-
-** xref:astream-subscriptions.adoc[Pulsar subscriptions]
+** Manage permissions
+*** xref:astream-org-permissions.adoc[]
+*** xref:astream-custom-roles.adoc[]
+** Pulsar subscriptions
+*** xref:astream-subscriptions.adoc[Pulsar subscriptions overview]
 *** xref:astream-subscriptions-exclusive.adoc[Exclusive]
 *** xref:astream-subscriptions-shared.adoc[Shared]
 *** xref:astream-subscriptions-failover.adoc[Failover]
 *** xref:astream-subscriptions-keyshared.adoc[Key_shared]
-
 * xref:streaming-learning:pulsar-io:connectors/index.adoc[IO Connectors]
 * xref:operations:astream-release-notes.adoc[Changelog]

--- a/modules/apis/nav.adoc
+++ b/modules/apis/nav.adoc
@@ -1,2 +1,3 @@
-* xref:index.adoc[]
-** xref:api-operations.adoc[API Operations]
+* API references
+** xref:index.adoc[API references overview]
+** xref:api-operations.adoc[API operations]

--- a/modules/developing/nav.adoc
+++ b/modules/developing/nav.adoc
@@ -6,17 +6,15 @@
 ** xref:astream-functions.adoc[]
 ** xref:astream-kafka.adoc[]
 ** xref:astream-rabbit.adoc[]
-
 ** Producing and consuming messages
 *** xref:produce-consume-astra-portal.adoc[Astra Portal]
 *** xref:produce-consume-pulsar-client.adoc[Pulsar Cli]
-*** xref:clients/index.adoc[Client Applications]
+*** Client applications
+**** xref:clients/index.adoc[Pulsar clients]
 **** xref:clients/java-produce-consume.adoc[Java]
 **** xref:clients/python-produce-consume.adoc[Python]
 **** xref:clients/csharp-produce-consume.adoc[C#]
 **** xref:clients/golang-produce-consume.adoc[Golang]
 **** xref:clients/nodejs-produce-consume.adoc[Node.js]
 **** xref:clients/spring-produce-consume.adoc[Spring]
-
-** Change data capture (CDC)
-*** xref:astream-cdc.adoc[]
+** xref:astream-cdc.adoc[]

--- a/modules/getting-started/nav.adoc
+++ b/modules/getting-started/nav.adoc
@@ -1,1 +1,1 @@
-* xref:index.adoc[Getting Started]
+* xref:index.adoc[Get started]

--- a/modules/operations/nav.adoc
+++ b/modules/operations/nav.adoc
@@ -1,13 +1,15 @@
-* xref:astream-georeplication.adoc[Operations]
+* Operations
 ** xref:astream-georeplication.adoc[]
 ** xref:astream-limits.adoc[]
 ** xref:astream-pricing.adoc[]
 ** xref:astream-regions.adoc[]
-** xref:monitoring/index.adoc[]
+** Monitoring streaming tentants
+*** xref:monitoring/index.adoc[Monitoring overview]
 *** xref:astream-scrape-metrics.adoc[]
 *** xref:monitoring/integration.adoc[]
 *** xref:monitoring/new-relic.adoc[]
-*** xref:monitoring/metrics.adoc[]
+*** Grafana dashboards
+**** xref:monitoring/metrics.adoc[]
 **** xref:monitoring/overview-dashboard.adoc[]
 **** xref:monitoring/namespace-dashboard.adoc[]
 **** xref:monitoring/topic-dashboard.adoc[]


### PR DESCRIPTION
Fix the nav.adoc files so there are no inaccessible pages (only available through breadcrumbs). With the new nav, the "parents" of categories can no longer be pages themselves.