### PR TITLE
payg and external links

### DIFF
--- a/modules/ROOT/pages/astream-faq.adoc
+++ b/modules/ROOT/pages/astream-faq.adoc
@@ -7,7 +7,7 @@
 Follow our simple xref:getting-started:index.adoc[getting started guide] to sign up for Astra and get your first streaming tenant created.
 
 == How is {product_name} priced?
-{product_name} offers customers a pay-as-you-go, consumption based pricing model that allows customers to use {product_name} with a cost model that scales as they grow.
+{product_name} offers customers a *Pay As You Go*, consumption based pricing model that allows customers to use {product_name} with a cost model that scales as they grow.
 
 Customers can opt to customize their deployment to meet specific requirements which will adjust their pricing up or down depending on their specific requirement. These customizations options include items such as:
 
@@ -19,7 +19,7 @@ Customers can opt to customize their deployment to meet specific requirements wh
 == Why did DataStax opt to base {product_name} on Apache Pulsar?
 See our https://www.datastax.com/blog/four-reasons-why-apache-pulsar-essential-modern-data-stack[blog post] that explains why we are excited about Apache Pulsar and why we decided it was the best technology to base {product_name} on.
 
-== What are DataStax’s plans for Kesque?
+== What is DataStax plan for Kesque?
 {product_name} is based heavily on technology originally created as part of Kesque. With the launch of {product_name} we will begin the process of shutting down the Kesque service and migrating customers to the new {product_name} platform.
 
 == How can I get started with {product_name}?
@@ -43,7 +43,7 @@ Each tenant can have multiple *namespaces*, a logical container for creating and
 A *topic* is a named channel for transmitting messages from producers to consumers.
 A *sink* feeds data from {product_name} to an external system, such as Cassandra or Elastic Search.
 
-== Next
+== See also
 
 * xref:getting-started:index.adoc[Getting started with Astra Streaming]
 * Browse the xref:apis:index.adoc[]

--- a/modules/apis/pages/api-operations.adoc
+++ b/modules/apis/pages/api-operations.adoc
@@ -240,7 +240,7 @@ Output: No reply means successful.
 
 == Namespace DevOps APIs
 
-For managing Astra Streaming Namespaces, we use the native https://pulsar.apache.org/admin-rest-api/[Pulsar REST APIs]{external-link-icon}.  These are documented on the Apache Pulsar Docs for REST API.
+For managing Astra Streaming Namespaces, we use the native https://pulsar.apache.org/admin-rest-api/[Pulsar REST APIs].  These are documented on the Apache Pulsar Docs for REST API.
 
 === List Existing Namespaces
 [tabs]

--- a/modules/apis/pages/index.adoc
+++ b/modules/apis/pages/index.adoc
@@ -8,15 +8,15 @@
 
 Management of Pulsar tenants and its resources are seperated into 2 APIs. The DevOps API is used to manage higher level objects associated with your account. The Pulsar Admin API is used to manage specific resources such as namespaces, topics, and subscriptions within a specific tenant.
 
-xref:astra-streaming:apis:attachment$devops.html[{product_name} DevOps API,role=external,window=_blank]{external-link-icon}
+xref:astra-streaming:apis:attachment$devops.html[{product_name} DevOps API,role=external]
 
 The Astra Streaming DevOps API is used to manage change data capture (CDC) settings, Pulsar tenants, geo-replications, Pulsar stats, and Pulsar tokens. This API uses your Astra Org token for bearer authentication.
 
-xref:astra-streaming:apis:attachment$pulsar-admin.html[{product_name} Pulsar Admin API,role=external,window=_blank]{external-link-icon}
+xref:astra-streaming:apis:attachment$pulsar-admin.html[{product_name} Pulsar Admin API,role=external]
 
 The Pulsar Admin API is used to manage Pulsar resources such as namespaces, topics, and subscriptions. This API uses your Pulsar token for bearer authentication.
 
 [NOTE]
-The open source Pulsar project offers https://pulsar.apache.org/admin-rest-api[documentation about the Pulsar Admin API^]. However, the Pulsar Admin API in Astra Streaming is slightly different. In OSS Pulsar you manage instances, the clusters within each instance, the tenants in the cluster, etc. +
+The open source Pulsar project offers https://pulsar.apache.org/admin-rest-api[documentation about the Pulsar Admin API]. However, the Pulsar Admin API in Astra Streaming is slightly different. In OSS Pulsar you manage instances, the clusters within each instance, the tenants in the cluster, etc. +
  +
 However, in Astra Streaming clusters are provided to you as a managed service, so you manage the tenants and resources within those tenants. Some endpoints have not been implemented in the Astra Streaming Pulsar Admin API because they are not applicable to the managed service.

--- a/modules/developing/pages/astra-cli.adoc
+++ b/modules/developing/pages/astra-cli.adoc
@@ -72,7 +72,7 @@ Result::
 
 == What's next?
 
-* See the {astra_cli} https://docs.datastax.com/en/astra-cli/docs/0.2/[documentation, window="_blank"].
+* See the {astra_cli} https://docs.datastax.com/en/astra-cli/docs/0.2/[documentation].
 
-* See the https://awesome-astra.github.io/docs/pages/astra/astra-cli/[Astra CLI install instructions^]{external-link-icon}.
+* See the https://awesome-astra.github.io/docs/pages/astra/astra-cli/[Astra CLI install instructions].
 

--- a/modules/developing/pages/astream-kafka.adoc
+++ b/modules/developing/pages/astream-kafka.adoc
@@ -104,6 +104,6 @@ video::Qy2ZlelLjXg[youtube, list=PL2g2h-wyI4SqeKH16czlcQ5x4Q_z-X7_m, height=445p
 
 == What's next?
 
-* {kafka_for_astra} is based on the DataStax https://github.com/datastax/starlight-for-kafka[Starlight for Kafka^] project.
+* {kafka_for_astra} is based on the DataStax https://github.com/datastax/starlight-for-kafka[Starlight for Kafka] project.
 
 * Follow our xref:getting-started:index.adoc[simple guide] to get started with Astra now.

--- a/modules/developing/pages/astream-rabbit.adoc
+++ b/modules/developing/pages/astream-rabbit.adoc
@@ -164,7 +164,7 @@ channel.basic_publish(exchange='header_logs',
 
 == What's Next?
 
-* {starlight_rabbitmq} is based on the DataStax https://github.com/datastax/starlight-for-rabbitmq[Starlight for RabbitMQ^] project.
+* {starlight_rabbitmq} is based on the DataStax https://github.com/datastax/starlight-for-rabbitmq[Starlight for RabbitMQ] project.
 * Follow our xref:getting-started:index.adoc[simple guide] to get started with Astra now.
 * For using Kafka with {product_name}, see xref:astream-kafka.adoc[Starlight for Kafka].
 

--- a/modules/developing/pages/clients/csharp-produce-consume.adoc
+++ b/modules/developing/pages/clients/csharp-produce-consume.adoc
@@ -6,18 +6,18 @@
 
 You will need the following prerequisites in place to complete this guide:
 
-* .NET 7 SDK installed (https://learn.microsoft.com/en-us/dotnet/core/install/[install now,title=Install .net sdk]{external-link-icon})
+* .NET 7 SDK installed (https://learn.microsoft.com/en-us/dotnet/core/install/[install now,title=Install .net sdk])
 * A working Pulsar topic (get started xref:getting-started:index.adoc[here] if you don't have a topic)
 * A basic text editor or IDE
 
 [TIP]
 ====
-Visit our https://github.com/datastax/astra-streaming-examples[examples repo^]{external-link-icon} to see the complete source of this example.
+Visit our https://github.com/datastax/astra-streaming-examples[examples repo] to see the complete source of this example.
 ====
 
 == Create a console project
 
-Create a new console project and add a reference to the https://www.nuget.org/packages/DotPulsar/[dotpulsar client^]{external-link-icon}
+Create a new console project and add a reference to the https://www.nuget.org/packages/DotPulsar/[dotpulsar client]
 
 [source,shell]
 ----

--- a/modules/developing/pages/clients/golang-produce-consume.adoc
+++ b/modules/developing/pages/clients/golang-produce-consume.adoc
@@ -14,7 +14,7 @@ You will need the following prerequisites in place to complete this guide:
 
 [TIP]
 ====
-Visit our https://github.com/datastax/astra-streaming-examples[examples repo^]{external-link-icon} to see the complete source of this example.
+Visit our https://github.com/datastax/astra-streaming-examples[examples repo] to see the complete source of this example.
 ====
 
 == Create a project

--- a/modules/developing/pages/clients/java-produce-consume.adoc
+++ b/modules/developing/pages/clients/java-produce-consume.adoc
@@ -8,14 +8,14 @@
 
 You will need the following prerequisites in place to complete this guide:
 
-* JRE 8 installed (https://sdkman.io/[install now^,title=Install java]{external-link-icon})
-* (https://maven.apache.org/install.html[Maven^,title=Maven]{external-link-icon}) or (https://gradle.org/install/[Gradle^,title=Gradle]{external-link-icon}) installed
+* JRE 8 installed (https://sdkman.io/[install now,title=Install java])
+* (https://maven.apache.org/install.html[Maven,title=Maven]) or (https://gradle.org/install/[Gradle,title=Gradle]) installed
 * A working Pulsar topic (get started xref:getting-started:index.adoc[here] if you don't have a topic)
 * A basic text editor or IDE
 
 [TIP]
 ====
-Visit our https://github.com/datastax/astra-streaming-examples[examples repo^]{external-link-icon} to see the complete source of this example.
+Visit our https://github.com/datastax/astra-streaming-examples[examples repo] to see the complete source of this example.
 ====
 
 == Create a project

--- a/modules/developing/pages/clients/nodejs-produce-consume.adoc
+++ b/modules/developing/pages/clients/nodejs-produce-consume.adoc
@@ -15,7 +15,7 @@ You will need the following prerequisites in place to complete this guide:
 
 [TIP]
 ====
-Visit our https://github.com/datastax/astra-streaming-examples[examples repo^]{external-link-icon} to see the complete source of this example.
+Visit our https://github.com/datastax/astra-streaming-examples[examples repo] to see the complete source of this example.
 ====
 
 == Setup environment

--- a/modules/developing/pages/clients/python-produce-consume.adoc
+++ b/modules/developing/pages/clients/python-produce-consume.adoc
@@ -15,7 +15,7 @@ You will need the following prerequisites in place to complete this guide:
 
 [TIP]
 ====
-Visit our https://github.com/datastax/astra-streaming-examples[examples repo^]{external-link-icon} to see the complete source of this example.
+Visit our https://github.com/datastax/astra-streaming-examples[examples repo] to see the complete source of this example.
 ====
 
 == Create a project

--- a/modules/developing/pages/clients/spring-produce-consume.adoc
+++ b/modules/developing/pages/clients/spring-produce-consume.adoc
@@ -7,21 +7,21 @@
 
 You will need the following prerequisites in place to complete this guide:
 
-* JRE 8 installed (https://sdkman.io/[install now^,title=Install java]{external-link-icon})
-* (https://maven.apache.org/install.html[Maven^,title=Maven]{external-link-icon}) or (https://gradle.org/install/[Gradle^,title=Gradle]{external-link-icon}) installed
+* JRE 8 installed (https://sdkman.io/[install now,title=Install java])
+* (https://maven.apache.org/install.html[Maven,title=Maven]) or (https://gradle.org/install/[Gradle,title=Gradle]) installed
 * A working Pulsar topic (get started xref:getting-started:index.adoc[here] if you don't have a topic)
 * A basic text editor or IDE
 
 [TIP]
 ====
-Visit our https://github.com/datastax/astra-streaming-examples[examples repo^]{external-link-icon} to see the complete source of this example.
+Visit our https://github.com/datastax/astra-streaming-examples[examples repo] to see the complete source of this example.
 ====
 
 == Create a Maven project in Spring Initializr
 
 Spring Initializr is a great tool to quickly create a project with the dependencies you need. Let's use it to create a project with the Pulsar client dependency.
 
-. Go to https://start.spring.io/[Spring Initializr^,title=Spring Initializr]{external-link-icon} to initalize a new project.
+. Go to https://start.spring.io/[Spring Initializr,title=Spring Initializr] to initalize a new project.
 . Select Maven, Java 17, a non-SNAPSHOT version of Spring Boot, and the Apache Pulsar dependency.
 +
 image::spring-initializr.png[Spring Initializr]

--- a/modules/developing/pages/configure-pulsar-env.adoc
+++ b/modules/developing/pages/configure-pulsar-env.adoc
@@ -11,7 +11,7 @@ This guide details the necessary steps to getting set up and validating the conn
 == Choosing a compatible version
 
 Pulsar is distributed as a single artifact.
-The Pulsar https://pulsar.apache.org/download/[download page^]{external-link-icon} offers the latest version, as well as older releases.
+The Pulsar https://pulsar.apache.org/download/[download page] offers the latest version, as well as older releases.
 
 Astra Streaming is currently compatible with Pulsar {pulsar_version}.
 Locate the latest patch version matching the major.minor version and download the binaries.
@@ -85,7 +85,7 @@ With your Astra Streaming tenant's configuration in place, you can use any of th
 With the Pulsar folder in place and the correct client configuration saved, the next step is to validate everything.
 Run each command to validate binary conf.
 
-TIP: For a full reference of all commands within the CLI, see the https://pulsar.apache.org/docs/reference-cli-tools/[Pulsar's CLI docs^]{external-link-icon}.
+TIP: For a full reference of all commands within the CLI, see the https://pulsar.apache.org/docs/reference-cli-tools/[Pulsar's CLI docs].
 
 List all tenants:
 [source,shell,subs="attributes+"]

--- a/modules/developing/pages/gpt-schema-translator.adoc
+++ b/modules/developing/pages/gpt-schema-translator.adoc
@@ -94,7 +94,7 @@ The {gpt-schema-translator} uses generative AI to automatically generate schema 
 == Prerequisites
 
 * An Astra Streaming cluster with a topic created. For more information, see the xref:getting-started:index.adoc[Getting Started] documentation.
-* An Astra database with a keyspace and table created. For more, see the https://docs.datastax.com/en/astra-serverless/docs/[Astra DB documentation^]{external-link-icon}.
+* An Astra database with a keyspace and table created. For more, see the https://docs.datastax.com/en/astra-serverless/docs/[Astra DB documentation].
 
 == Usage
 

--- a/modules/developing/pages/using-curl.adoc
+++ b/modules/developing/pages/using-curl.adoc
@@ -9,7 +9,7 @@ When you create a tenant in Astra Streaming, all supporting APIs are enabled.
 To interact with your Astra Streaming tenant you will need two pieces of information: a token and the service URL.
 This guide will show you how to gather that information and test your connection.
 
-TIP: The https://pulsar.apache.org/docs/2.10.x/reference-rest-api-overview/[Pulsar documentation^]{external-link-icon} has a full reference for each API supported in a cluster. +
+TIP: The https://pulsar.apache.org/docs/2.10.x/reference-rest-api-overview/[Pulsar documentation]} has a full reference for each API supported in a cluster. +
 This reference will be helpful as you look to automate certain actions in your Astra Streaming tenant.
 
 == Finding your tenant's web service URL
@@ -46,7 +46,7 @@ Most APIs use *tokens* to authenticate a request, and Pulsar follows this same p
 
 [NOTE]
 ====
-Don't confuse your Pulsar token with your Astra token - the concept is the same, but it's a different authentication. xref:operations:astream-token-gen.adoc[More details are here,window="_blank"].
+Don't confuse your Pulsar token with your Astra token - the concept is the same, but it's a different authentication. xref:operations:astream-token-gen.adoc[More details are here].
 ====
 
 To create a new Pulsar token in your Astra Streaming tenant, navigate to the "Settings" tab in the Astra portal.

--- a/modules/getting-started/pages/index.adoc
+++ b/modules/getting-started/pages/index.adoc
@@ -40,7 +40,7 @@ image:astream-create-account.png[Create Astra account]
 
 Think of a tenant in Astra Streaming as your safe space to work.
 It is a portion of DataStax's managed Apache Pulsar that is only yours.
-Learn more about the concept of tenancy in the https://pulsar.apache.org/docs/concepts-multi-tenancy/[Pulsar docs^]{external-link-icon}.
+Learn more about the concept of tenancy in the https://pulsar.apache.org/docs/concepts-multi-tenancy/[Pulsar docs].
 
 The steps in the below tabs will guide you through creating a Streaming Tenant.
 You'll use this tenant to create namespaces, topics, functions, and pretty much everything else.
@@ -79,7 +79,7 @@ Astra CLI::
 +
 --
 {astra_cli} is a set of commands for creating and managing all Astra resources.
-For more, see the https://docs.datastax.com/en/astra-cli/docs/0.2/[documentation, window="_blank"]{external-link-icon}.
+For more, see the https://docs.datastax.com/en/astra-cli/docs/0.2/[documentation].
 
 . Set the required variables, replacing <rand> with a few random numbers or letters.
 Optionally you can choose a different cloud provider and region. Use `astra streaming list-regions` to see values.
@@ -110,7 +110,7 @@ A namespace is a logical grouping of message topics.
 Tenants usually have many namespaces.
 What is contained within namespace is limited only by your imagination.
 It could be an environment (dev, stage, prod) or by application (catalog, cart, user) or whatever logical grouping makes sense to you.
-Learn more about namespaces in the https://pulsar.apache.org/docs/concepts-messaging/#namespaces[Pulsar docs^]{external-link-icon}.
+Learn more about namespaces in the https://pulsar.apache.org/docs/concepts-messaging/#namespaces[Pulsar docs].
 
 [NOTE]
 ====
@@ -146,7 +146,7 @@ a|image:namespace-listing.png[Namespaces in Astra Streaming]
 Pulsar Admin::
 +
 --
-Not sure about this? Learn more about xref:developing:configure-pulsar-env.adoc[configuring your local environment for Astra Streaming,window="_blank"]{external-link-icon}.
+Not sure about this? Learn more about xref:developing:configure-pulsar-env.adoc[configuring your local environment for Astra Streaming].
 
 . Set the required variables.
 +
@@ -167,7 +167,7 @@ include::{astra-streaming-examples-repo}/pulsar-admin/create-namespace.sh[]
 Curl::
 +
 --
-Not sure about this? Learn more about interacting with Astra Streaming through curl xref:developing:using-curl.adoc[here,window="_blank"]{external-link-icon}.
+Not sure about this? Learn more about interacting with Astra Streaming through curl xref:developing:using-curl.adoc[here].
 
 . Set the required variables.
 +
@@ -196,7 +196,7 @@ The name of the topic usually loosely defines the criteria, and more advanced ch
 Topics are where others can "listen" for new messages.
 Consumers subscribe to topics to "listen" for messages, and functions and connectors can also "listen" for messages and automate workflows.
 In Pulsar, topic addresses look like a URL (ie: persistent://tenant/namespace/topic).
-Learn more about topics in the https://pulsar.apache.org/docs/concepts-messaging/#topics[Pulsar docs^]{external-link-icon}.
+Learn more about topics in the https://pulsar.apache.org/docs/concepts-messaging/#topics[Pulsar docs].
 
 [tabs]
 ====
@@ -206,7 +206,7 @@ Astra Portal::
 . In the *Namespace And Topics* tab, locate the namespace created above and click its *Add Topic* button.
 . Provide a name for the topic like "my-topic".
 It must start with a lowercase letter, be alphanumeric, and can contain hyphens.
-. Leave the choice of persistence and partitioning alone for now - those can be a part of https://pulsar.apache.org/docs/concepts-messaging/#partitioned-topics[future learning^]{external-link-icon} :).
+. Leave the choice of persistence and partitioning alone for now - those can be a part of https://pulsar.apache.org/docs/concepts-messaging/#partitioned-topics[future learning].
 +
 [width=75%]
 |===
@@ -245,7 +245,7 @@ include::{astra-streaming-examples-repo}/pulsar-admin/create-topic.sh[]
 Curl::
 +
 --
-Not sure about this? Learn more about interacting with Astra Streaming through curl xref:developing:using-curl.adoc[here,window="_blank"]{external-link-icon}.
+Not sure about this? Learn more about interacting with Astra Streaming through curl xref:developing:using-curl.adoc[here].
 
 . Set the required variables.
 +

--- a/modules/operations/pages/astream-pricing.adoc
+++ b/modules/operations/pages/astream-pricing.adoc
@@ -3,5 +3,5 @@
 :page-tag: astra-streaming,planner,plan,pulsar
 :page-aliases: docs@astra-streaming::astream-pricing.adoc
 
-For information on *pricing* for {product_name}, see https://www.datastax.com/products/astra-streaming/pricing[Astra Streaming pricing^]{external-link-icon}.
+For information on *pricing* for {product_name}, see https://www.datastax.com/products/astra-streaming/pricing[Astra Streaming pricing].
 

--- a/modules/operations/pages/astream-scrape-metrics.adoc
+++ b/modules/operations/pages/astream-scrape-metrics.adoc
@@ -133,5 +133,5 @@ Cluster operational metrics are *not* exposed to individual cluster tenants. A t
 
 * For more on monitoring Astra Streaming with Prometheus and Grafana, see xref:monitoring/index.adoc[].
 * Follow our xref:getting-started:index.adoc[getting started guide] to get started with Astra now.
-* For more on Prometheus, see the https://prometheus.io/docs/introduction/overview/[Prometheus docs^].
+* For more on Prometheus, see the https://prometheus.io/docs/introduction/overview/[Prometheus docs].
 

--- a/modules/operations/pages/monitoring/index.adoc
+++ b/modules/operations/pages/monitoring/index.adoc
@@ -1,16 +1,16 @@
 = Monitoring Streaming Tenants
 
-Because Astra Streaming is a software-as-a-service product, not all Apache Pulsar metrics (https://pulsar.apache.org/docs/reference-metrics/[Pulsar Metrics Reference^]{external-link-icon}) are exposed for external integration purposes. At a high level, Astra Streaming only exposes metrics that are related to namespaces. Other metrics that are not directly namespace related are not exposed externally, such as the Bookkeeper ledger and journal metrics and Zookeeper metrics.
+Because Astra Streaming is a software-as-a-service product, not all Apache Pulsar metrics (https://pulsar.apache.org/docs/reference-metrics/[Pulsar Metrics Reference]) are exposed for external integration purposes. At a high level, Astra Streaming only exposes metrics that are related to namespaces. Other metrics that are not directly namespace related are not exposed externally, such as the Bookkeeper ledger and journal metrics and Zookeeper metrics.
 
-In the following sections, we’ll explore each of the Astra Streaming metrics categories that are available for external integration, and recommended metrics for external integration.
+In the following sections, we'll explore each of the Astra Streaming metrics categories that are available for external integration, and recommended metrics for external integration.
 
 == Pulsar raw metrics
 
 For a complete Pulsar metrics reference, see:
 
-* https://pulsar.apache.org/docs/reference-metrics/#namespace-metrics[Namespace metrics^]{external-link-icon}
+* https://pulsar.apache.org/docs/reference-metrics/#namespace-metrics[Namespace metrics]
 
-* https://pulsar.apache.org/docs/reference-metrics/#topic-metrics[Topic metrics^]{external-link-icon}
+* https://pulsar.apache.org/docs/reference-metrics/#topic-metrics[Topic metrics]
 
 For a complete Astra Streaming metrics reference, see xref:monitoring/metrics.adoc[].
 
@@ -69,7 +69,7 @@ include::example$sink-connector-metrics.csv[]
 
 == Aggregate Astra Streaming Metrics
 
-Each externally exposed raw Astra Streaming metric is reported at a very low level, at each individual server instance (the `exported_instance` label) and each topic partition (the `topic` label). The same raw metrics could come from multiple server instances. From a {product_name} user’s perspective, the direct monitoring of raw metrics is not really useful. Raw metrics need to be aggregated first - for example, by averaging or summing the raw metrics over a period of time.
+Each externally exposed raw Astra Streaming metric is reported at a very low level, at each individual server instance (the `exported_instance` label) and each topic partition (the `topic` label). The same raw metrics could come from multiple server instances. From a {product_name} user's perspective, the direct monitoring of raw metrics is not really useful. Raw metrics need to be aggregated first - for example, by averaging or summing the raw metrics over a period of time.
 
 Below is an example of a raw metric for the Pulsar message backlog (pulsar_msg_backlog) scraped from an Astra Streaming cluster located in the GCP US Central region:
 
@@ -84,52 +84,52 @@ pulsar_msg_backlog{app="pulsar", cluster="pulsar-gcp-uscentral1", component="bro
 To make raw metrics like this useful for end users, we recommend the following guidelines when aggregating raw metrics:
 
 . Aggregate metrics to at least the parent topic level, instead of at the partition level. In Pulsar, end user applications only deal with messages at the parent topic level (but internally, Pulsar is handling message processing at the partition level).
-. Exclude reported metrics that are associated with Astra Streaming’s system namespaces and topics. These namespaces and topics normally have a name starting with ++__++ (two underscores). For example, when Pulsar’s Kafka protocol handler is enabled (via S4K integration), a system namespace ++__kafka++ is created with one system topic within called ++__transaction_producer_state++.
-Do NOT aggregate metrics with the Astra Streaming PAYG option, since one cluster may be shared among multiple organizations. For more, see xref:astream-limits.adoc[Cluster Limits].
+. Exclude reported metrics that are associated with Astra Streaming's system namespaces and topics. These namespaces and topics normally have a name starting with ++__++ (two underscores). For example, when Pulsar's Kafka protocol handler is enabled (via S4K integration), a system namespace ++__kafka++ is created with one system topic within called ++__transaction_producer_state++.
+Do NOT aggregate metrics with the Astra Streaming *Pay As You Go* option, since one cluster may be shared among multiple organizations. For more, see xref:astream-limits.adoc[Cluster Limits].
 
 === PromQL query patterns
 
-Prometheus provides a powerful but easy-to-use query language called PromQL for selecting and aggregating time series data in real time. PromQL syntax is beyond this document's scope, but the https://prometheus.io/docs/prometheus/latest/querying/basics/[Prometheus documentation^]{external-link-icon} is a great place to start.
+Prometheus provides a powerful but easy-to-use query language called PromQL for selecting and aggregating time series data in real time. PromQL syntax is beyond this document's scope, but the https://prometheus.io/docs/prometheus/latest/querying/basics/[Prometheus documentation] is a great place to start.
 
-In the rest of this section, we’ll recommend some PromQL query patterns for aggregating raw Astra Streaming metrics.
+In the rest of this section, we'll recommend some PromQL query patterns for aggregating raw Astra Streaming metrics.
 These examples use one Astra Streaming raw metric, pulsar_msg_backlog, as an example for illustrative purposes.
 We aggregate messages at the parent topic level or above, and exclude system topics per our recommendations above.
 We filter out system messages with the pattern +{topic !~ ".*__.*"}+.
 This PromQL pattern filters out messages when their topic labels do not include +__+.
 This works because Pulsar system topics usually have ++__++ as the topic or namespace name prefix (e.g. persistent://<tenant>/++__++kafka/__consumer_offsets_partition_0).
-This pattern assumes that the user applications don’t also have namespaces and topics with +__+ as part of the names, or they will be filtered as well.
+This pattern assumes that the user applications don't also have namespaces and topics with +__+ as part of the names, or they will be filtered as well.
 
 Pattern 1: Get the total message backlog of a specific parent topic, excluding system topics.
-"$ptopic” is a (Grafana dashboard) variable that represents a specific parent topic.
+"$ptopic" is a (Grafana dashboard) variable that represents a specific parent topic.
 [source,psql]
 ----
 sum(pulsar_msg_backlog{topic=~$ptopic, topic !~ ".*__.*"})
 ----
 
 Pattern 2: Get the total message backlog of a specific namespace, excluding system topics.
-“$namespace” is a (Grafana dashboard) variable that represents a specific namespace.
+"$namespace" is a (Grafana dashboard) variable that represents a specific namespace.
 [source,psql]
 ----
-sum(pulsar_msg_backlog{namespace=~”$namespace”, topic !~ ".*__.*"})
+sum(pulsar_msg_backlog{namespace=~"$namespace", topic !~ ".*__.*"})
 ----
 
 Pattern 3: Get the total message backlog of a tenant, excluding system topics.
-"$tenant” is a (Grafana dashboard) variable that represents a specific tenant.
+"$tenant" is a (Grafana dashboard) variable that represents a specific tenant.
 [source,psql]
 ----
-sum(pulsar_msg_backlog{namespace=~”$tenant.+”, topic !~ ".*__.*"})
+sum(pulsar_msg_backlog{namespace=~"$tenant.+"", topic !~ ".*__.*"})
 ----
 
 Pattern 4: Get the total message backlog of each topic within a specific namespace, excluding system topics.
 [source,psql]
 ----
-sum by(topic) (pulsar_msg_backlog{namespace=~”$namespace”, topic !~ ".*__.*"})
+sum by(topic) (pulsar_msg_backlog{namespace=~"$namespace", topic !~ ".*__.*"})
 ----
 
 Pattern 5: Get the top 10 message backlog by topic within a specific namespace, excluding system topics.
 [source,psql]
 ----
-topk by(topic) (10, sum(pulsar_msg_backlog{namespace=~”$namespace”, topic !~ ".*__.*"})
+topk by(topic) (10, sum(pulsar_msg_backlog{namespace=~"$namespace", topic !~ ".*__.*"})
 ----
 
 == Metrics to be alerted
@@ -151,7 +151,7 @@ A simple way to trigger an alert on these metrics is to set a threshold which tr
 A better approach is calculating the metrics' increase rate over a period of time (e.g. 1 hour) and setting a threshold on the rate of increase.
 For example, if the average message backlog increase rate exceeds a threshold, an alert is triggered.
 
-The actual threshold values for these metrics is highly dependent on each application’s workload and requirements, but the values should be relatively large positive numbers, e.g. several hundreds or several thousands.
+The actual threshold values for these metrics is highly dependent on each application's workload and requirements, but the values should be relatively large positive numbers, e.g. several hundreds or several thousands.
 Otherwise, they may trigger too many false alarms.
 
 == What's next?

--- a/modules/operations/pages/monitoring/integration.adoc
+++ b/modules/operations/pages/monitoring/integration.adoc
@@ -15,7 +15,7 @@ This document will show you how to set up a Prometheus server in a Kubernetes cl
 
 == Configure and deploy Prometheus
 
-In this example, we use the https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack[Prometheus Community Kubernetes Helm Charts^]{external-link-icon} to set up a Prometheus server and a Grafana server in a K8s cluster.
+In this example, we use the https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack[Prometheus Community Kubernetes Helm Charts] to set up a Prometheus server and a Grafana server in a K8s cluster.
 
 . Create a configuration yaml file (e.g. astra-msgenrich.yml) using the Astra Streaming Prometheus configuration from the UI.
 For more on downloading the Prometheus configuration from the Astra Streaming UI, see https://docs.datastax.com/en/streaming/astra-streaming/operations/astream-scrape-metrics.html[Scrape metrics from Astra Streaming].

--- a/modules/operations/pages/monitoring/metrics.adoc
+++ b/modules/operations/pages/monitoring/metrics.adoc
@@ -6,7 +6,7 @@ This article is a continuation of xref:monitoring/index.adoc[]. Please read that
 ====
 
 DataStax has built Grafana dashboards around core message processing for the exposed Astra Streaming metrics.
-The dashboards can be found https://github.com/datastax/astra-streaming-examples/tree/master/grafana-dashboards[on GitHub^]{external-link-icon}.
+The dashboards can be found https://github.com/datastax/astra-streaming-examples/tree/master/grafana-dashboards[on GitHub].
 
 Dashboards are available for scraping metrics at Pulsar's tenant, namespace, and topic levels:
 

--- a/modules/operations/pages/monitoring/namespace-dashboard.adoc
+++ b/modules/operations/pages/monitoring/namespace-dashboard.adoc
@@ -1,6 +1,6 @@
 = Namespace dashboard
 
-The https://github.com/datastax/astra-streaming-examples/blob/master/grafana-dashboards/as-namespace.json[namespace dashboard^]{external-link-icon} aggregates metrics at the namespace level. In the variable section, you can choose a cluster, tenant, and namespace.
+The https://github.com/datastax/astra-streaming-examples/blob/master/grafana-dashboards/as-namespace.json[namespace dashboard] aggregates metrics at the namespace level. In the variable section, you can choose a cluster, tenant, and namespace.
 
 == Namespace overview
 Namespace overview displays the aggregated total metrics values summarized at the namespace level.

--- a/modules/operations/pages/monitoring/new-relic.adoc
+++ b/modules/operations/pages/monitoring/new-relic.adoc
@@ -5,11 +5,11 @@
 This article is a continuation of xref:monitoring/index.adoc[]. Please read that article first to understand the fundamentals of what resources are being used.
 ====
 
-According to the https://docs.newrelic.com/[New Relic documentation^]{external-link-icon}, there are 3 different ways to integrate external Prometheus data into New Relic:
+According to the https://docs.newrelic.com/[New Relic documentation], there are 3 different ways to integrate external Prometheus data into New Relic:
 
-* Option 1: https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/#Agent[Prometheus Agent for Kubernetes^]{external-link-icon}
-* Option 2: https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/#OpenMetrics[Prometheus OpenMetrics integration for Docker^]{external-link-icon}
-* Option 3: https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/#remote-write[Prometheus remote write integration^]{external-link-icon}
+* Option 1: https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/#Agent[Prometheus Agent for Kubernetes]
+* Option 2: https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/#OpenMetrics[Prometheus OpenMetrics integration for Docker]
+* Option 3: https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/#remote-write[Prometheus remote write integration]
 
 Options 1 and 2 are not relevant for Astra Streaming, so option 3 is the only possible solution.
 Option 3 would require modifying the configuration of the Prometheus server which Astra Streaming relies on, but due to the managed-service nature of Astra Streaming, this is not possible. Instead, an extra Prometheus server can be installed (per the instructions in xref:monitoring/integration.adoc[]) to act as a bridge to forward scraped Astra Streaming metrics to New Relic. The diagram below shows this idea:
@@ -18,7 +18,7 @@ Option 3 would require modifying the configuration of the Prometheus server whic
 image::monitoring-map.png[Map,align="center"]
 
 == Prerequisites
-* https://docs.newrelic.com/[Set up a New Relic account^]{external-link-icon}
+* https://docs.newrelic.com/[Set up a New Relic account]
 * When creating a New Relic account, it will generate a license key. Save this key to a local file for usage in later steps.
 
 == Configure New Relic

--- a/modules/operations/pages/monitoring/overview-dashboard.adoc
+++ b/modules/operations/pages/monitoring/overview-dashboard.adoc
@@ -1,6 +1,6 @@
 = Overview dashboard
 
-The https://github.com/datastax/astra-streaming-examples/blob/master/grafana-dashboards/as-overview.json[overview dashboard^]{external-link-icon} has three major sections which display the highest aggregation level - tenant level, tenant level with namespace level separation, and the variable section, where you can choose a cluster and a tenant.
+The https://github.com/datastax/astra-streaming-examples/blob/master/grafana-dashboards/as-overview.json[overview dashboard] has three major sections which display the highest aggregation level - tenant level, tenant level with namespace level separation, and the variable section, where you can choose a cluster and a tenant.
 
 == Tenant overview
 Overview displays the aggregated total metrics values summarized at the tenant level. The following metrics are included:

--- a/modules/operations/pages/monitoring/topic-dashboard.adoc
+++ b/modules/operations/pages/monitoring/topic-dashboard.adoc
@@ -1,6 +1,6 @@
 = Topic dashboard
 
-The https://github.com/datastax/astra-streaming-examples/blob/master/grafana-dashboards/as-topic.json[topic dashboard^]{external-link-icon} aggregates metrics at the topic level. In the variable section, you can choose a cluster, tenant, and namespace, and topic.
+The https://github.com/datastax/astra-streaming-examples/blob/master/grafana-dashboards/as-topic.json[topic dashboard] aggregates metrics at the topic level. In the variable section, you can choose a cluster, tenant, and namespace, and topic.
 This dashboard analyzes metrics at the parent topic level, not at the partition level.
 
 == Topic overview

--- a/modules/operations/pages/onboarding-faq.adoc
+++ b/modules/operations/pages/onboarding-faq.adoc
@@ -15,23 +15,23 @@ The Streaming team is available to assist you in any way we can.
 .What are the different ways I can use Astra Streaming?
 [%collapsible]
 ====
-Astra Streaming offers two types of serverless environments: *Pay-As-You-Go (PAYG)* and *dedicated*. +
-When you create a free account in Astra (with or without a credit card) you are using the *PAYG* option.
-When a payment method is provided, you are paying only for resources used when messages are produced and consumed.
-Thus, you are "paying as you go".
-In PAYG environments, your data and interaction with Pulsar are secured over a (public) internet connection, and there are limitations to how many resources you can create.
+Astra Streaming offers two types of serverless environments: *Pay As You Go* and *dedicated*.
+If your Astra organization is on the *Free* plan, you use the *Pay As You Go* streaming option.
+When you provide a payment method, you only pay for resources used when messages are produced and consumed.
+Therefore, you _pay as you go_.
+In *Pay As You Go* streaming environments, your data and interaction with Pulsar are secured over a (public) internet connection, and there are limitations to how many resources you can create.
 
-* For more on PAYG pricing, see https://www.datastax.com/products/astra-streaming/pricing[Astra Streaming Pricing^]{external-link-icon}. +
-* For more on PAYG limits, see xref:astream-limits.adoc[Astra Streaming Limits].
+* For more on *Pay As You Go* streaming pricing, see https://www.datastax.com/products/astra-streaming/pricing[Astra Streaming Pricing].
+* For more on *Pay As You Go* streaming limits, see xref:astream-limits.adoc[Astra Streaming Limits].
 
 A *dedicated environment* is your own private Pulsar cluster with the additional benefits of Astra Streaming.
-Sign in to Astra just as you would a PAYG account.
+Sign in to Astra just as you would with a *Pay As You Go* streaming account.
 When you create new tenants, additional options are available for deploying to your private cluster(s).
-There are less limits in dedicated environments than in PAYG - it's your cluster, after all.
+There are less limits in *dedicated environments* than in *Pay As You Go* - it's your cluster, after all.
 Finally, billing for a dedicated cluster is unique to each customer. +
 mailto:streaming@datastax.com[Contact the team] to learn more.
 
-TIP: In a PAYG environment, you can create tenants in any of the xref:astream-regions.adoc[supported regions], while dedicated environments are open to almost any public cloud region.
+TIP: In a *Pay As You Go* environment, you can create tenants in any of the xref:astream-regions.adoc[supported regions], while *dedicated environments* are open to almost any public cloud region.
 ====
 
 .Why does DataStax call it "serverless"?
@@ -52,13 +52,15 @@ Serverless removes those operational burdens, and you pay only for the resources
 All connections in Astra Streaming are guarded by AuthN, AuthZ, and secure (TLS) communications.
 With a dedicated cluster you have the option to connect over the (public) internet or establish a private connection. To learn more about private connections, refer to your cloud provider's private link documentation:
 
-https://aws.amazon.com/privatelink/[AWS PrivateLink^]{external-link-icon} &nbsp;|&nbsp; https://learn.microsoft.com/en-us/azure/private-link/private-link-overview[Azure Private Link^]{external-link-icon} &nbsp;|&nbsp; https://cloud.google.com/vpc/docs/private-service-connect[GCP Private Service Connect^]{external-link-icon}
+* https://aws.amazon.com/privatelink/[AWS PrivateLink]
+* https://learn.microsoft.com/en-us/azure/private-link/private-link-overview[Azure Private Link]
+* https://cloud.google.com/vpc/docs/private-service-connect[GCP Private Service Connect]
 ====
 
-.Can a PAYG account have a private connection to the Pulsar cluster?
+.Can a Pay As You Go streaming account have a private connection to the Pulsar cluster?
 [%collapsible]
 ====
-PAYG accounts are using a shared Pulsar cluster. Without dedicated cloud resources, a private link typically can’t be established. mailto:streaming@datastax.com[Email the team] if you would like to explore this option.
+*Pay As You Go* streaming accounts use a shared Pulsar cluster. Without dedicated cloud resources, a private link typically can't be established. mailto:streaming@datastax.com[Email the team] if you would like to explore this option.
 ====
 
 == Secure Sign-on, Roles, and Permissions
@@ -66,22 +68,22 @@ PAYG accounts are using a shared Pulsar cluster. Without dedicated cloud resourc
 .Can I use my own single sign-on with Astra Streaming?
 [%collapsible]
 ====
-As a PAYG customer, the Astra platform offers single sign-on through your GitHub account and your Google account.
+As a *Pay As You Go* customer, the Astra platform offers single sign-on through your GitHub account and your Google account.
 Astra also offers custom SSO integration as a premium option. mailto:streaming@datastax.com[Email the team] for more information.
 
 NOTE: To integrate a custom SSO provider, you will need a non-default Astra Organization.
-Refer to the https://docs.datastax.com/en/astra-serverless/docs/manage/org/configuring-sso.html[Astra Serverless SSO documentation^]{external-link-icon} or mailto:streaming@datastax.com[email the team] for more information.
+Refer to the https://docs.datastax.com/en/astra-serverless/docs/manage/org/configuring-sso.html[Astra Serverless SSO documentation] or mailto:streaming@datastax.com[email the team] for more information.
 ====
 
 .How do Astra roles and permissions map to Pulsar roles and permissions?
 [%collapsible]
 ====
-Pulsar has the concept of https://pulsar.apache.org/docs/security-authorization/[clients with role tokens^]{external-link-icon}. Authentication in Pulsar is the process of verifying a provided (JWT) token, and authorization is the process of determining if the role claimed in that token is allowed to complete the requested action.
+Pulsar has the concept of https://pulsar.apache.org/docs/security-authorization/[clients with role tokens]. Authentication in Pulsar is the process of verifying a provided (JWT) token, and authorization is the process of determining if the role claimed in that token is allowed to complete the requested action.
 
 Astra Streaming uses the DataStax version of Apache Pulsar (called xref:luna-streaming::index.adoc[Luna Streaming]).
-The https://github.com/datastax/pulsar[Luna project^]{external-link-icon} is an open fork of the Pulsar project that maintains feature parity with OSS Pulsar. Astra Streaming, as a managed service, abstracts some features/options of Pulsar to ensure continuous, reliable service.
+The https://github.com/datastax/pulsar[Luna project] is an open fork of the Pulsar project that maintains feature parity with OSS Pulsar. Astra Streaming, as a managed service, abstracts some features/options of Pulsar to ensure continuous, reliable service.
 
-Your PAYG environment is an Astra Organization (Org) that has a tenant (or multiple tenants) on a shared Pulsar cluster.
+Your *Pay As You Go* environment is an Astra Organization (Org) that has a tenant (or multiple tenants) on a shared Pulsar cluster.
 Each of your tenants is secured by Pulsar AuthN & AuthZ models *and* the Astra Org AuthN and AuthZ.
 The shared cluster is created and administered by Astra Streaming Admins.
 Each tenant is assigned a custom role (and permission) limited to only that tenant.
@@ -94,21 +96,21 @@ All tokens created within a tenant are assigned roles similar to the assigning t
 The Astra platform offers different layers of authentication based on the desired action.
 In general, actions related to your Astra Org (members, org billing, usage metrics, etc.) use your Astra Token, and actions specific to a Pulsar tenant (message namespaces, topics, message metrics, etc.) use a Pulsar JWT token.
 
-If you would like to get a little deeper into exactly which token covers what action, see the following guides and documentation.
+If you would like to get a little deeper into exactly which token covers what action, see the following documentation:
 
-xref:astra-streaming:developing:astra-cli.adoc[] +
-xref:astra-streaming:developing:using-curl.adoc[] +
-xref:astra-streaming:developing:configure-pulsar-env.adoc[] +
-https://awesome-astra.github.io/docs/pages/astra/astra-cli/#astra-streaming[Astra Streaming functions of the Astra CLI^]{external-link-icon}
+* xref:astra-streaming:developing:astra-cli.adoc[]
+* xref:astra-streaming:developing:using-curl.adoc[]
+* xref:astra-streaming:developing:configure-pulsar-env.adoc[]
 ====
 
 == Data Migration and Geo-replication
 
-.What are the differences between dedicated and PAYG geo-replication?
+.What are the differences between dedicated and Pay As You Go geo-replication?
 [%collapsible]
 ====
-Geo-replication is available to both PAYG and dedicated serverless environments. Both can replicate to other clusters, but there are some differences. +
-In PAYG, traffic between clusters will be secured over the (public) internet, while dedicated clusters have the option for private communication. PAYG environments can replicate between any xref:astream-regions.adoc[supported region] of the same cloud provider. With dedicated clusters, you can use almost any region supported by your cloud provider, as well as across cloud providers.
+Geo-replication is available to both *Pay As You Go* and *dedicated serverless environments*. Both can replicate to other clusters, but there are some differences.
+
+In *Pay As You Go* streaming, traffic between clusters is secured over the (public) internet, while dedicated clusters have the option for private communication. *Pay As You Go* environments can replicate between any xref:astream-regions.adoc[supported region] of the same cloud provider. With dedicated clusters, you can use almost any region supported by your cloud provider, as well as across cloud providers.
 mailto:streaming@datastax.com[Email the team] for more information.
 
 For more on geo-replication, see xref:astream-georeplication.adoc[].
@@ -150,7 +152,7 @@ All tokens would have access to all namespaces.
 .Can we develop applications on open source Pulsar and then move to Astra Streaming?
 [%collapsible]
 ====
-As mentioned previously, Astra Streaming is actively maintained to keep parity with the official https://pulsar.apache.org[Apache Pulsar project^]{external-link-icon}.
+As mentioned previously, Astra Streaming is actively maintained to keep parity with the official https://pulsar.apache.org[Apache Pulsar project].
 The notable differences arise from accessibility and security.
 Naturally, you have less control in a managed, serverless cluster than you do in a cluster running in your own environment.
 Beyond those differences, the effort to develop locally and then move to Astra Streaming should not be significant, but it is recommended to develop directly in Astra Streaming.

--- a/modules/ragstack/pages/index.adoc
+++ b/modules/ragstack/pages/index.adoc
@@ -8,11 +8,11 @@ Instead of managing forks and installing dozens of open-source packages while wo
 
 DataStax has been busy helping our customers through the pains of RAG implementation, so the {ragstack} components we've selected have withstood production workloads and stringent testing by our engineering teams for performance, compatibility, and security.
 
-* {ragstack} leverages the https://python.langchain.com/docs/get_started/introduction[LangChain^]{external-link-icon} ecosystem and is fully compatible with https://docs.smith.langchain.com/[LangSmith^]{external-link-icon} (for monitoring) and https://github.com/langchain-ai/langserve[LangServe^]{external-link-icon} (for hosting).
+* {ragstack} leverages the https://python.langchain.com/docs/get_started/introduction[LangChain] ecosystem and is fully compatible with https://docs.smith.langchain.com/[LangSmith] (for monitoring) and https://github.com/langchain-ai/langserve[LangServe] (for hosting).
 
 * The https://docs.datastax.com/en/astra-serverless/docs/[AstraDB] vector database provides the best performance and scalability for RAG applications, in addition to being particularly well-suited to RAG workloads like question answering, semantic search, and semantic caching.
 
-* The https://langstream.ai[LangStream^]{external-link-icon} package combines the best of event-based architectures with the latest Gen AI technologies. Develop robust Gen AI pipelines with just YAML files. Leverage Kafka for data flow, and Kubernetes for deployment and scaling.
+* The https://langstream.ai[LangStream] package combines the best of event-based architectures with the latest Gen AI technologies. Develop robust Gen AI pipelines with just YAML files. Leverage Kafka for data flow, and Kubernetes for deployment and scaling.
 
 == Why {ragstack}?
 

--- a/modules/ragstack/pages/quickstart.adoc
+++ b/modules/ragstack/pages/quickstart.adoc
@@ -16,7 +16,7 @@ Install the {ragstack} CLI:
 brew install datastax/ragstack/ragstack
 ----
 
-For more on the {ragstack} CLI, see https://docs.langstream.ai/installation/langstream-cli[{ragstack} CLI^]{external-link-icon}.
+For more on the {ragstack} CLI, see https://docs.langstream.ai/installation/langstream-cli[{ragstack} CLI].
 
 == Enable {ragstack} in Astra
 
@@ -139,7 +139,7 @@ The values for the Kafka bootstrap server are found in your Astra Streaming tena
 The Azure access key and URL are found in your Azure OpenAI deployment.
 A secrets.yaml file can be downloaded from the Connect tab of your Astra Streaming tenant.
 Paste it into your secrets.yaml file to authorize your application to your tenant.
-For more on finding values for secrets, see https://docs.langstream.ai/building-applications/secrets.html[Secrets^]{external-link-icon}.
+For more on finding values for secrets, see https://docs.langstream.ai/building-applications/secrets.html[Secrets].
 [source,yaml]
 ----
 secrets:
@@ -181,11 +181,11 @@ export GOOGLE_CLIENT_ID=xxxx.apps.googleusercontent.com
 ----
 [NOTE]
 ====
-For more on creating a Google client ID, see https://developers.google.com/identity/protocols/oauth2#serviceaccount[Google Service Account^]{external-link-icon}.
+For more on creating a Google client ID, see https://developers.google.com/identity/protocols/oauth2#serviceaccount[Google Service Account].
 ====
 
 Pipeline.yaml contains the chain of agents that makes up your program, and the input and output topics that they communicate with.
-For more on building pipelines, see https://docs.langstream.ai/building-applications/pipelines[Pipelines^]{external-link-icon}.
+For more on building pipelines, see https://docs.langstream.ai/building-applications/pipelines[Pipelines].
 [source,yaml]
 ----
 topics:
@@ -227,7 +227,7 @@ pipeline:
 ----
 
 Gateways.yaml contains API gateways for communicating with your application.
-For more on gateways and authentication, see https://docs.langstream.ai/building-applications/api-gateways[API Gateways^]{external-link-icon}.
+For more on gateways and authentication, see https://docs.langstream.ai/building-applications/api-gateways[API Gateways].
 [source,yaml]
 ----
 gateways:
@@ -301,7 +301,7 @@ gateways:
 
 Configuration.yaml contains additional configuration and resources for your application.
 A configuration.yaml file can be downloaded from the Connect tab of your Astra Streaming tenant (under AstraDB).
-For more on configuration, see https://docs.langstream.ai/building-applications/configuration[Configuration^]{external-link-icon}.
+For more on configuration, see https://docs.langstream.ai/building-applications/configuration[Configuration].
 [source,yaml]
 ----
 configuration:
@@ -320,7 +320,7 @@ Remember to save all your yaml files.
 
 To deploy the application, run the following commands from the root of your application folder.
 The first command deploys the application from the YAML files you created above, and the second command gets the status of the application.
-For more on {ragstack} CLI commands, see https://docs.langstream.ai/installation/langstream-cli[{ragstack} CLI^]{external-link-icon}.
+For more on {ragstack} CLI commands, see https://docs.langstream.ai/installation/langstream-cli[{ragstack} CLI].
 [tabs]
 ====
 {ragstack} CLI::
@@ -486,5 +486,5 @@ Connected to wss://lsgwy-gcp-useast1.streaming.datastax.com/langstream-api-gatew
 
 {ragstack} is built with the LangStream framework, which is a set of tools for building Generative AI streaming applications.
 
-For more, see https://github.com/LangStream/langstream[GitHub^]{external-link-icon}.
+For more, see https://github.com/LangStream/langstream[GitHub].
 


### PR DESCRIPTION
* Standardize spelling of Pay As You Go per PRTL-393.
* Remove new window function from all links except Astra Portal links.