### PR TITLE
DOC-4872: Update namespace per tenant limit

### DIFF
--- a/modules/operations/pages/astream-limits.adoc
+++ b/modules/operations/pages/astream-limits.adoc
@@ -24,7 +24,7 @@ a|
 |This limit can't be changed for shared clusters.
 
 |Number of namespaces per tenant
-|All cluster: 10
+|All cluster: 20
 |
 
 |Number of topics per namespace


### PR DESCRIPTION
This pull request includes a change to the `modules/operations/pages/astream-limits.adoc` file to update the cluster limits.

Cluster limit update:

* Increased the number of namespaces per tenant from 10 to 20 for all clusters.