### PR TITLE
max-partitions-per-topic

### DIFF
--- a/modules/operations/pages/astream-limits.adoc
+++ b/modules/operations/pages/astream-limits.adoc
@@ -24,7 +24,7 @@ a|
 |This limit can't be changed for shared clusters.
 
 |Number of namespaces per tenant
-|All cluster: 20
+|All clusters: 20
 |
 
 |Number of topics per namespace
@@ -61,6 +61,10 @@ If there are multiple subscriptions to a topic, they can dispatch a _combined ma
 
 |Auto topic creation
 |All clusters: Disabled
+|
+
+|Max number of partitions per topic
+|All clusters: 128
 |
 
 |Number of producers per topic


### PR DESCRIPTION
This pull request includes updates to the `astream-limits.adoc` file to correct a minor typo and add a new limit for the number of partitions per topic.

Updates to `astream-limits.adoc`:

* Corrected typo in the "Number of namespaces per tenant" section to ensure consistent pluralization.
* Added a new limit for the "Max number of partitions per topic" across all clusters.