### PR TITLE
DOC-5016 Replace CDC content with docs-common

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -22,6 +22,7 @@ asciidoc:
     astra-ui-link: '{astra-url}[{astra-ui}^]'
     db-serverless-vector: 'Serverless (Vector)'
     devops-api: 'DevOps API'
+    devops-api-ref-url: 'xref:astra-api-docs:ROOT:attachment$devops-api/index.html'
     cass: 'Apache Cassandra'
     cass-reg: 'Apache Cassandra(R)'
     cass-short: 'Cassandra'

--- a/antora.yml
+++ b/antora.yml
@@ -20,6 +20,7 @@ asciidoc:
     astra-ui: 'Astra Portal'
     astra-url: 'https://astra.datastax.com'
     astra-ui-link: '{astra-url}[{astra-ui}^]'
+    db-serverless-vector: 'Serverless (Vector)'
     devops-api: 'DevOps API'
     cass: 'Apache Cassandra'
     cass-reg: 'Apache Cassandra(R)'

--- a/local-preview-playbook.yml
+++ b/local-preview-playbook.yml
@@ -56,7 +56,6 @@ asciidoc:
     company: 'DataStax'
     astra_db: 'Astra DB'
     astra_stream: 'Astra Streaming'
-    astra-stream: 'Astra Streaming'
     astra_ui: 'Astra Portal'
     astra_cli: 'Astra CLI'
     astra-streaming-examples-repo: 'https://raw.githubusercontent.com/datastax/astra-streaming-examples/master'

--- a/local-preview-playbook.yml
+++ b/local-preview-playbook.yml
@@ -56,6 +56,7 @@ asciidoc:
     company: 'DataStax'
     astra_db: 'Astra DB'
     astra_stream: 'Astra Streaming'
+    astra-stream: 'Astra Streaming'
     astra_ui: 'Astra Portal'
     astra_cli: 'Astra CLI'
     astra-streaming-examples-repo: 'https://raw.githubusercontent.com/datastax/astra-streaming-examples/master'

--- a/modules/apis/pages/index.adoc
+++ b/modules/apis/pages/index.adoc
@@ -6,7 +6,7 @@ You use two APIs to manage {pulsar-reg} tenants and their resources.
 
 == {product} {devops-api}
 
-Use the xref:astra-streaming:apis:attachment$devops.html[{product} {devops-api}] to manage higher-level {product} objects associated with your {astra-db} organization, such as the change data capture (CDC) settings, {pulsar-short} tenants, geo-replications, {pulsar-short} stats, and {pulsar-short} tokens.
+Use the xref:astra-streaming:apis:attachment$devops.html[{product} {devops-api}] to manage higher-level {product} objects associated with your {astra-db} organization, such as the Change Data Capture (CDC) settings, {pulsar-short} tenants, geo-replications, {pulsar-short} stats, and {pulsar-short} tokens.
 
 This API uses an {astra-db} application token for authentication.
 

--- a/modules/developing/nav.adoc
+++ b/modules/developing/nav.adoc
@@ -20,7 +20,6 @@
 *** xref:ROOT:astream-subscriptions-shared.adoc[]
 *** xref:ROOT:astream-subscriptions-failover.adoc[]
 *** xref:ROOT:astream-subscriptions-keyshared.adoc[]
-* xref:gpt-schema-translator.adoc[]
-* xref:astra-cli.adoc[]
 * xref:astream-cdc.adoc[]
+* xref:gpt-schema-translator.adoc[]
 * xref:streaming-learning:pulsar-io:connectors/index.adoc[IO connectors]

--- a/modules/developing/pages/astream-cdc.adoc
+++ b/modules/developing/pages/astream-cdc.adoc
@@ -1,14 +1,5 @@
-= Create a Change Data Capture (CDC) connector
-:description: CDC for {astra-db} automatically captures changes in real time, de-duplicates the changes, and streams the clean set of changed data
+= Enable Change Data Capture for {astra-db}
+:navtitle: Enable Change Data Capture (CDC)
+:description: CDC for {astra-db} automatically captures changes in real time, de-duplicates the changes, and streams the clean set of changed data to {product}.
 
-[IMPORTANT]
-====
-Enabling CDC for {astra-db} databases incurs billed charges based on your {product} usage.
-See https://www.datastax.com/pricing/astra-streaming[{product} pricing] and https://www.datastax.com/products/datastax-astra/cdc-for-astra-db[CDC metering rates].
-====
-
-CDC for {astra-db} automatically captures changes in real time, de-duplicates the changes, and streams the clean set of changed data into {product} where it can be processed by client applications or sent to downstream systems.
-
-{product} processes data changes via an {pulsar-reg} topic. By design, the Change Data Capture (CDC) component is simple, with a 1:1 correspondence between the table and a single {pulsar-short} topic.
-
-For instructions and more information about CDC for {astra-db}, see xref:astra-db-serverless:databases:change-data-capture.adoc[].
+include::common:streaming:partial$cdc/cdc-for-astra-db.adoc[]

--- a/modules/developing/pages/produce-consume-pulsar-client.adoc
+++ b/modules/developing/pages/produce-consume-pulsar-client.adoc
@@ -4,7 +4,7 @@
 
 You can use the `pulsar-client` CLI to produce and consume messages in your {product} tenants.
 
-. xref:getting-started:index.adoc[Create a {product} tenant.]
+. xref:getting-started:index.adoc[Create an {product} tenant.]
 
 . xref:developing:configure-pulsar-env.adoc[Configure {pulsar-reg} binaries for {product}.]
 

--- a/modules/developing/pages/using-curl.adoc
+++ b/modules/developing/pages/using-curl.adoc
@@ -29,7 +29,7 @@ Web Service URLs start with `http`.
 Broker Service URLs start with `pulsar(+ssl)`.
 ====
 
-== Create a {product} {pulsar-short} token
+== Create an {product} {pulsar-short} token
 
 [IMPORTANT]
 ====

--- a/modules/getting-started/pages/index.adoc
+++ b/modules/getting-started/pages/index.adoc
@@ -13,7 +13,7 @@ This quickstart demonstrates how to create and use a streaming tenant running {p
 
 == Create a streaming tenant
 
-A {product} tenant is a portion of {company}-managed {pulsar} that is only yours.
+An {product} tenant is a portion of {company}-managed {pulsar} that is only yours.
 Within tenants, you create namespaces, topics, functions, and more.
 To learn more about the concept of tenancy, see the https://pulsar.apache.org/docs/concepts-multi-tenancy/[{pulsar-short} documentation].
 

--- a/modules/operations/nav.adoc
+++ b/modules/operations/nav.adoc
@@ -3,7 +3,7 @@
 * xref:operations:astream-pricing.adoc[]
 * xref:operations:astream-regions.adoc[]
 * xref:operations:astream-georeplication.adoc[]
-* xref:astra-cli.adoc[]
+* xref:developing:astra-cli.adoc[]
 * Monitor streaming tenants
 ** xref:operations:monitoring/index.adoc[]
 ** xref:operations:astream-scrape-metrics.adoc[]

--- a/modules/operations/nav.adoc
+++ b/modules/operations/nav.adoc
@@ -3,6 +3,7 @@
 * xref:operations:astream-pricing.adoc[]
 * xref:operations:astream-regions.adoc[]
 * xref:operations:astream-georeplication.adoc[]
+* xref:astra-cli.adoc[]
 * Monitor streaming tenants
 ** xref:operations:monitoring/index.adoc[]
 ** xref:operations:astream-scrape-metrics.adoc[]

--- a/modules/operations/pages/astream-regions.adoc
+++ b/modules/operations/pages/astream-regions.adoc
@@ -1,16 +1,16 @@
 = {product} regions
 :page-tag: astra-streaming,admin,manage,pulsar
+:description: {product} is available in specific AWS, Microsoft Azure, and Google Cloud regions.
 
-When you create a tenant, you must choose a region for your tenant.
-{product} supports AWS, Microsoft Azure, and Google Cloud regions.
-For optimal performance, choose a region that is geographically close to your users.
+{product} is available in a subset of the xref:astra-db-serverless:databases:regions.adoc[{astra-db} regions], including AWS, Microsoft Azure, and Google Cloud regions.
 
-These regions also support CDC for {astra-db}.
-You can only use xref:developing:astream-cdc.adoc[CDC for {astra-db}] in regions that support both {product} and {astra-db}.
+{astra-stream} tenants are regionally isolated.
+The region you select when you create a tenant determines which databases that tenant can support.
+For example, to enable xref:developing:astream-cdc.adoc[CDC for {astra-db}], your tenant must be in the same region as the relevant database.
 
-ElasticSearch and Snowflake can be in different regions than {product}.
+Your ElasticSearch and Snowflake deployments can be in different regions than your {product} tenants.
 
-== AWS
+== AWS regions for {product}
 
 [cols="1,1"]
 |===
@@ -41,29 +41,7 @@ ElasticSearch and Snowflake can be in different regions than {product}.
 |Oregon
 |===
 
-== Microsoft Azure
-
-[cols="1,1"]
-|===
-|Region |Location
-
-|`australiaeast`
-|New South Wales
-
-|`eastus`
-|Virginia
-
-// |`eastus2`
-// |Virginia
-
-|`westeurope`
-|Netherlands
-
-|`westus2`
-|Washington
-|===
-
-== Google Cloud
+== Google Cloud regions for {product}
 
 [cols="1,1"]
 |===
@@ -88,3 +66,29 @@ ElasticSearch and Snowflake can be in different regions than {product}.
 |Virginia
 
 |===
+
+== Microsoft Azure regions for {product}
+
+[cols="1,1"]
+|===
+|Region |Location
+
+|`australiaeast`
+|New South Wales
+
+|`eastus`
+|Virginia
+
+// |`eastus2`
+// |Virginia
+
+|`westeurope`
+|Netherlands
+
+|`westus2`
+|Washington
+|===
+
+== Request a region
+
+If your preferred region isn't available, contact your {company} account representative or {support_url}[{company} Support].

--- a/modules/operations/pages/astream-regions.adoc
+++ b/modules/operations/pages/astream-regions.adoc
@@ -22,6 +22,9 @@ ElasticSearch and Snowflake can be in different regions than {product}.
 |`ap-southeast-1`
 |Singapore
 
+// |`ap-southeast-2`
+// |Sydney
+
 |`eu-central-1`
 |Frankfurt
 
@@ -67,18 +70,21 @@ ElasticSearch and Snowflake can be in different regions than {product}.
 |Region |Location
 
 |`australia-southeast1`
-|Sydney, Australia
+|Sydney
 
 |`europe-west1`
-|St. Ghislain, Belgium
+|Belgium
+
+// |`europe-west3`
+// |Frankfurt
 
 |`us-central1`
-|Council Bluffs, Iowa
+|Iowa
 
 |`us-east1`
-|Moncks Corner, South Carolina
+|South Carolina
 
 |`us-east4`
-|Ashburn, Virginia
+|Virginia
 
 |===

--- a/modules/operations/pages/monitoring/index.adoc
+++ b/modules/operations/pages/monitoring/index.adoc
@@ -84,7 +84,7 @@ Do _not_ aggregate metrics on shared clusters because one cluster can be shared 
 For more information, see xref:astream-limits.adoc[] and xref:operations:astream-pricing.adoc[].
 ====
 
-Each externally exposed raw {product} metric is reported at a very low level, at each individual server instance (the `exported_instance` label) and each topic partition (the `topic` label). The same raw metrics could come from multiple server instances. From a {product} user's perspective, the direct monitoring of raw metrics is not really useful. Raw metrics need to be aggregated first - for example, by averaging or summing the raw metrics over a period of time.
+Each externally exposed raw {product} metric is reported at a very low level, at each individual server instance (the `exported_instance` label) and each topic partition (the `topic` label). The same raw metrics could come from multiple server instances. From an {product} user's perspective, the direct monitoring of raw metrics is not really useful. Raw metrics need to be aggregated first - for example, by averaging or summing the raw metrics over a period of time.
 
 The following example shows some raw metrics for a {pulsar-short} message backlog (`pulsar_msg_backlog`) scraped from an {product} cluster in the Google Cloud `us-central1` region:
 

--- a/modules/operations/pages/monitoring/stream-audit-logs.adoc
+++ b/modules/operations/pages/monitoring/stream-audit-logs.adoc
@@ -5,7 +5,7 @@ Stream your xref:astra-db-serverless:administration:view-account-audit-log.adoc[
 To enable audit log streaming, you must do one of the following:
 
  * Provide the **Full Name** of your {product} topic and the streaming tenant's `client.conf` file to {support_url}[{company} Support] or your {company} account representative.
- * POST your configuration to the xref:astra-api-docs:ROOT:attachment$devops-api/index.html#tag/Organization-Operations/operation/configureTelemetry[{astra-db} {devops-api} telemetry endpoint].
+ * POST your configuration to the {devops-api-ref-url}#tag/Organization-Operations/operation/configureTelemetry[{astra-db} {devops-api} telemetry endpoint].
 
 == Create an {product} topic for audit logs
 
@@ -35,7 +35,7 @@ You can use topics to organize audit logs by event type or other criteria.
 [#use-the-devops-api]
 == Configure audit log streaming with the {devops-api}
 
-You can use the xref:astra-api-docs:ROOT:attachment$devops-api/index.html#tag/Organization-Operations/operation/configureTelemetry[{astra-db} {devops-api} telemetry endpoint] to configure audit log streaming instead of providing the configuration details to {company} Support.
+You can use the {devops-api-ref-url}#tag/Organization-Operations/operation/configureTelemetry[{astra-db} {devops-api} telemetry endpoint] to configure audit log streaming instead of providing the configuration details to {company} Support.
 
 . In the {astra-ui-link}, create an {astra-db} application token with the **Organization Administrator** role.
 
@@ -102,4 +102,4 @@ curl -sS --location -X GET "https://api.astra.datastax.com/v2/organizations/**OR
 
 == Delete an audit log streaming configuration
 
-To delete an audit log streaming configuration, xref:astra-api-docs:ROOT:attachment$devops-api/index.html#tag/Organization-Operations/operation/deleteTelemetryConfig[send a DELETE request].
+To delete an audit log streaming configuration, {devops-api-ref-url}#tag/Organization-Operations/operation/deleteTelemetryConfig[send a DELETE request].

--- a/modules/operations/pages/private-connectivity.adoc
+++ b/modules/operations/pages/private-connectivity.adoc
@@ -47,7 +47,7 @@ The private link service pattern is the same across cloud providers, but the hos
 On a case-by-case basis, {product} can support private outbound traffic flowing from {product} to your private endpoint.
 
 The outbound traffic pattern creates a private endpoint in {product} that connects to your private link service.
-{company} opens a port on the tenant's firewall to allow connectors and functions running in a dedicated namespace on a {product} cluster to connect to your private network.
+{company} opens a port on the tenant's firewall to allow connectors and functions running in a dedicated namespace on an {product} cluster to connect to your private network.
 Each tenant has its own firewall.
 
 [#credentials]


### PR DESCRIPTION
* Moved CDC content to docs-common.
* Replace contents of astream-cdc.adoc with the docs-common `include`
* Slight change to nav - Astra CLI felt misplaced under Development, moved it under Operations?
* Small copyedits related to CDC content updates

Preview build of CDC page: https://d5rxiv0do0q3v.cloudfront.net/doc-5016/astra-streaming/developing/astream-cdc.html 