### PR TITLE
docs: fix patch 404 in binaries page

### DIFF
--- a/modules/developing/pages/configure-pulsar-env.adoc
+++ b/modules/developing/pages/configure-pulsar-env.adoc
@@ -11,7 +11,10 @@ To get started, you must download a compatible {pulsar-short} artifact, and then
 
 {product} is compatible with {pulsar-short} version {pulsar-version}.
 
-. Download the binaries for the https://pulsar.apache.org/download/[latest {pulsar-version} patch release]:
+. Download the binaries for the https://pulsar.apache.org/download/[latest {pulsar-version} patch release].
++
+Replace `**PATCH**` with the specific patch version you want to use.
+For example, to download Pulsar version `3.1.0`, use patch version `0`.
 +
 [source,shell,subs="+quotes,+attributes"]
 ----

--- a/modules/operations/pages/astream-regions.adoc
+++ b/modules/operations/pages/astream-regions.adoc
@@ -4,7 +4,7 @@
 
 {product} is available in a subset of the xref:astra-db-serverless:databases:regions.adoc[{astra-db} regions], including AWS, Microsoft Azure, and Google Cloud regions.
 
-{astra-stream} tenants are regionally isolated.
+{product} tenants are regionally isolated.
 The region you select when you create a tenant determines which databases that tenant can support.
 For example, to enable xref:developing:astream-cdc.adoc[CDC for {astra-db}], your tenant must be in the same region as the relevant database.
 


### PR DESCRIPTION
Clarify binary patch usage.

Unrelated: fix a partial that was causing an error in astream-regions.