### PR TITLE
DOC-4942 - Astra FTUX for Astra Streaming docs

### DIFF
--- a/modules/developing/pages/astream-functions.adoc
+++ b/modules/developing/pages/astream-functions.adoc
@@ -287,7 +287,7 @@ See <<controlling-your-function,Controlling your function>> for more information
 
 == Deploy functions in the {astra-ui}
 
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, and then select *Streaming*.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], and then select *Streaming*.
 
 . Click the name of the tenant where you want to deploy a function.
 
@@ -393,7 +393,7 @@ Your function should output the result of processing the message.
 [#controlling-your-function]
 === Stop and start functions
 
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, and then select *Streaming*.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], and then select *Streaming*.
 
 . Click the name of the tenant where you want to manage functions, and then click the *Functions* tab.
 
@@ -403,7 +403,7 @@ Your function should output the result of processing the message.
 
 Functions produce logs to help you debug them.
 
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, and then select *Streaming*.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], and then select *Streaming*.
 
 . Click the name of the tenant that you want to debug, and then click the *Functions* tab.
 
@@ -415,7 +415,7 @@ If you specified a log topic when deploying your function, function logs also ou
 
 === Edit functions
 
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, and then select *Streaming*.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], and then select *Streaming*.
 
 . Click the name of the tenant where your function is deployed, and then click the *Functions* tab.
 
@@ -436,7 +436,7 @@ If you need to change any other function settings, you must delete and redeploy 
 Deleting a function is permanent.
 ====
 
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, and then select *Streaming*.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], and then select *Streaming*.
 
 . Click the name of the tenant where you want to delete a function, and then click the *Functions* tab.
 

--- a/modules/developing/pages/clients/spring-produce-consume.adoc
+++ b/modules/developing/pages/clients/spring-produce-consume.adoc
@@ -101,7 +101,7 @@ Message received: Hello World
 ----
 ====
 
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, and then select *Streaming*.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], and then select *Streaming*.
 
 . Click the name of your tenant, and then verify that the message appears in the specified namespace and topic.
 

--- a/modules/developing/pages/configure-pulsar-env.adoc
+++ b/modules/developing/pages/configure-pulsar-env.adoc
@@ -44,7 +44,7 @@ The executables in `/bin` use the configurations in `/conf` to run commands.
 Each tenant you create in {product} comes with its own custom configuration for SSO, endpoints, and so on.
 You must download the tenant configuration from {product}, and then overwrite the `./conf/client.conf` file.
 
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, and then select *Streaming*.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], and then select *Streaming*.
 
 . Click the name of your tenant.
 

--- a/modules/developing/pages/gpt-schema-translator.adoc
+++ b/modules/developing/pages/gpt-schema-translator.adoc
@@ -23,7 +23,7 @@ The {gpt-schema-translator} is available for the {astra-db} sink connector only.
 This example uses a JSON schema for a {pulsar-short} topic, and a CQL schema for an {astra-db} table.
 The {gpt-schema-translator} generates a mapping between the two schemas that the {astra-db} sink connector can use to write data from the {pulsar-short} topic to the {astra-db} table.
 
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, and then select *Streaming*.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], and then select *Streaming*.
 
 . Click the name of your tenant.
 

--- a/modules/developing/pages/produce-consume-astra-portal.adoc
+++ b/modules/developing/pages/produce-consume-astra-portal.adoc
@@ -9,7 +9,7 @@ The following steps will use the "Try Me" feature of the {astra-ui} to interact 
 
 == Select the producer and consumer topics
 
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, and then select *Streaming*.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], and then select *Streaming*.
 
 . Click the name of your tenant.
 

--- a/modules/developing/pages/using-curl.adoc
+++ b/modules/developing/pages/using-curl.adoc
@@ -12,7 +12,7 @@ Depending on the API you use, you need certain information to form HTTP requests
 
 == Get the tenant web service URL
 
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, and then select *Streaming*.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], and then select *Streaming*.
 
 . Click the name of your tenant.
 

--- a/modules/developing/partials/client-variables-table.adoc
+++ b/modules/developing/partials/client-variables-table.adoc
@@ -5,7 +5,7 @@
 |`serviceUrl`
 |The URL to connect to the {pulsar-short} cluster
 a|
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, and then select *Streaming*.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], and then select *Streaming*.
 . Click the name of your tenant, and then click the *Connect* tab.
 . In the *Tenant Details* section, get the *Broker Service URL*.
 
@@ -16,20 +16,20 @@ a|
 |`tenantName`
 |The name of your streaming tenant
 a|
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, and then select *Streaming*.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], and then select *Streaming*.
 . Get the name from the *Tenants* list.
 
 |`namespace`
 |The segmented area for certain topics in your streaming tenant
 a|
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, and then select *Streaming*.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], and then select *Streaming*.
 . Click the name of your tenant, and then click the *Namespace and Topics* tab.
 . Choose the target namespace from the list of namespaces.
 
 |`topicName`
 |Topic name (not the full name)
 a|
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, and then select *Streaming*.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], and then select *Streaming*.
 . Click the name of your tenant, and then click the *Namespace and Topics* tab.
 . Expand the target namespace in the list of namespaces to view the names of the topics within.
 Do _not_ use the *Full Name*.

--- a/modules/getting-started/pages/index.adoc
+++ b/modules/getting-started/pages/index.adoc
@@ -20,7 +20,7 @@ To learn more about the concept of tenancy, see the https://pulsar.apache.org/do
 You can create a tenant in the {astra-ui} or programmatically.
 For this quickstart, use the {astra-ui}.
 
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, and then select *Streaming*.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], and then select *Streaming*.
 
 . Click *Create a Tenant*.
 
@@ -49,7 +49,7 @@ You can create namespaces in the {astra-ui} or programmatically.
 For this quickstart, use the {astra-ui}.
 For information about the {pulsar-short} CLI or APIs, see xref:developing:configure-pulsar-env.adoc[] and xref:developing:using-curl.adoc[].
 
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, and then select *Streaming*.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], and then select *Streaming*.
 
 . Click the name of your tenant.
 
@@ -74,7 +74,7 @@ To learn more about topics, see the https://pulsar.apache.org/docs/concepts-mess
 
 As in the previous steps, you can create topics in the {astra-ui} or programmatically.
 
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, and then select *Streaming*.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], and then select *Streaming*.
 
 . Click the name of your tenant.
 

--- a/modules/operations/pages/astream-georeplication.adoc
+++ b/modules/operations/pages/astream-georeplication.adoc
@@ -131,7 +131,7 @@ key:[null], properties:[], content:hello-from-pulsar
 key:[null], properties:[], content:hello-from-pulsar
 ----
 
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, and then select *Streaming*.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], and then select *Streaming*.
 
 . Click the name of your tenant, and then click the **Namespaces and Topics** tab.
 

--- a/modules/operations/pages/astream-scrape-metrics.adoc
+++ b/modules/operations/pages/astream-scrape-metrics.adoc
@@ -11,7 +11,7 @@ This doc will show you how to scrape an {product} tenant with Prometheus.
 
 == Get the configuration file from {product}
 
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, and then select *Streaming*.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], and then select *Streaming*.
 
 . Click the name of your tenant, and then click the *Connect* tab.
 

--- a/modules/operations/pages/astream-token-gen.adoc
+++ b/modules/operations/pages/astream-token-gen.adoc
@@ -19,7 +19,7 @@ You need a {pulsar-short} JWT for actions related to {pulsar-short} tenants, nam
 
 You can generate, copy, or delete {product} {pulsar-short} tokens for each of your {product} tenants:
 
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, and then select *Streaming*.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], and then select *Streaming*.
 
 . Click the name of your tenant where you want to manage tokens.
 

--- a/modules/operations/pages/monitoring/stream-audit-logs.adoc
+++ b/modules/operations/pages/monitoring/stream-audit-logs.adoc
@@ -12,7 +12,7 @@ To enable audit log streaming, you must do one of the following:
 Audit log streaming requires a streaming tenant in the AWS `us-east-2` region.
 You can create a new tenant with the xref:astra-streaming:getting-started:index.adoc[{product} quickstart] or use an existing {product} tenant.
 
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, and then select *Streaming*.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], and then select *Streaming*.
 
 . Click the name of an existing tenant or create a streaming tenant in AWS `us-east-2`, and then create a namespace and topic in the tenant.
 +
@@ -23,7 +23,7 @@ For more information about creating tenants, namespaces, and topics, see xref:as
 . If necessary, create additional audit log topics, and then record the **Full Name** for each topic.
 You can use topics to organize audit logs by event type or other criteria.
 
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, select *Streaming*, and then click the name of your audit log streaming tenant.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], select *Streaming*, and then click the name of your audit log streaming tenant.
 
 . On the *Connect* tab, click **Download client.conf**.
 
@@ -37,7 +37,7 @@ You can use topics to organize audit logs by event type or other criteria.
 
 You can use the {devops-api-ref-url}#tag/Organization-Operations/operation/configureTelemetry[{product-short} {devops-api} telemetry endpoint] to configure audit log streaming instead of providing the configuration details to {company} Support.
 
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, and then select *Admin*.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], and then select *Admin*.
 
 . Click **Tokens**, and then create an xref:astra-db-serverless:administration:manage-application-tokens.adoc[{product-short} application token] with the **Organization Administrator** role.
 

--- a/modules/operations/pages/private-connectivity.adoc
+++ b/modules/operations/pages/private-connectivity.adoc
@@ -22,7 +22,7 @@ To use a private link service or private endpoint for {product}, do the followin
 
 . Get the name of the {product} clusters where you want to enable private connectivity.
 +
-. In the {astra-ui-link} header, click icon:material-icons:apps[] **Applications**, select *Streaming*, and then find cluster names in the *Tenants* list.
+. In the {astra-ui-link} header, click icon:grip[name="Applications"], select *Streaming*, and then find cluster names in the *Tenants* list.
 
 . Get your cloud provider resource identifier:
 +


### PR DESCRIPTION
Update primary Astra Portal navigation for FTUX project.

Notable previews:

* [astream-functions.adoc](https://d5rxiv0do0q3v.cloudfront.net/doc-4942/astra-streaming/developing/astream-functions.html#deploy-functions-in-the-astra-portal)
* [example of client-variables-table.adoc](https://d5rxiv0do0q3v.cloudfront.net/doc-4942/astra-streaming/developing/clients/python-produce-consume.html#write-the-script) (step 2)
* [getting-started/index.adoc](https://d5rxiv0do0q3v.cloudfront.net/doc-4942/astra-streaming/getting-started/index.html#create-a-streaming-tenant)
* [stream-audit-logs.adoc](https://d5rxiv0do0q3v.cloudfront.net/doc-4942/astra-streaming/operations/monitoring/stream-audit-logs.html)