### PR TITLE
DOC-5810: Use composite URL attributes for version-specific pulsar/debezium links 

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -57,6 +57,7 @@ asciidoc:
     pulsar-admin-functions-cli-ref-url: 'https://pulsar.apache.org/docs/{pulsar-version}.x/functions-cli'
     pulsar-admin-sinks-ref-url: 'https://pulsar.apache.org/reference/#/{pulsar-version}.x/pulsar-admin/sinks'
     pulsar-admin-sources-ref-url: 'https://pulsar.apache.org/reference/#/{pulsar-version}.x/pulsar-admin/sources'
+    pulsar-person-class-spec-url: 'https://github.com/apache/pulsar/blob/branch-{pulsar-version}/pulsar-io/data-generator/src/main/java/org/apache/pulsar/io/datagenerator/Person.java'
     debezium-release-url: 'https://debezium.io/releases/{debezium-version}'
 
     # Astra role attributes (compare with astra-vector-docs antora.yml)

--- a/antora.yml
+++ b/antora.yml
@@ -54,6 +54,10 @@ asciidoc:
     scb: 'Secure Connect Bundle (SCB)'
     scb-short: 'SCB'
     scb-brief: 'Secure Connect Bundle'
+    pulsar-admin-functions-cli-ref-url: 'https://pulsar.apache.org/docs/{pulsar-version}.x/functions-cli'
+    pulsar-admin-sinks-ref-url: 'https://pulsar.apache.org/reference/#/{pulsar-version}.x/pulsar-admin/sinks'
+    pulsar-admin-sources-ref-url: 'https://pulsar.apache.org/reference/#/{pulsar-version}.x/pulsar-admin/sources'
+    debezium-release-url: 'https://debezium.io/releases/{debezium-version}'
 
     # Astra role attributes (compare with astra-vector-docs antora.yml)
     organization-administrator-role: 'xref:astra-db-serverless:administration:rbac.adoc#organization-administrator-role[Organization Administrator]'


### PR DESCRIPTION
Jira: [DOC-5810](https://datastax.jira.com/browse/DOC-5810)

The `antora.yml` updates associated with https://github.com/riptano/docs-common/pull/398.


[DOC-5810]: https://datastax.jira.com/browse/DOC-5810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ